### PR TITLE
Runner.Base: add {:error, atom()} to result_t type

### DIFF
--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -8,6 +8,7 @@ defmodule K8s.Client.Runner.Base do
           | {:error, K8s.Middleware.Error.t()}
           | {:error, :connection_not_registered}
           | {:error, :missing_required_param}
+          | {:error, atom()}
           | {:error, binary()}
 
   @typedoc "Acceptable HTTP body types"


### PR DESCRIPTION
The HTTP client can, for example, return {:error, :not_found}, and this is not
covered in the typespec.