### PR TITLE
watch: do not encode = as %3D in fieldSelector

### DIFF
--- a/lib/k8s/client/runner/watch.ex
+++ b/lib/k8s/client/runner/watch.ex
@@ -102,7 +102,7 @@ defmodule K8s.Client.Runner.Watch do
   defp get_to_list(get_op) do
     list_op = %{get_op | verb: :list, path_params: []}
     name = get_op.path_params[:name]
-    params = %{"fieldSelector" => "metadata.name%3D#{name}"}
+    params = %{"fieldSelector" => "metadata.name=#{name}"}
     {list_op, params}
   end
 end


### PR DESCRIPTION
Kubernetes fails with 400 BadRequest if it receives the fieldSelector in that
format, while it succeeds using =.