### PR TITLE
Support query params in Operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- K8s.Operation `query_params` map. `labelSelector` 
+- Deprecated HTTPoison options being passed to K8s.Client.Runner.base
+- K8s.Operation.put_query_param/3 to add query parameters by key 
+- K8s.Operation.get_query_param/3 to get a query parameter by key
+
 ### Changed
 - Refactored old references to `cluster_name` to `conn`
 

--- a/lib/k8s/selector.ex
+++ b/lib/k8s/selector.ex
@@ -56,7 +56,7 @@ defmodule K8s.Selector do
       iex> K8s.Client.get("v1", :pods)
       ...> |> K8s.Selector.label({"app", "nginx"})
       ...> |> K8s.Selector.label_in({"environment", ["qa", "prod"]})
-      %K8s.Operation{data: nil, api_version: "v1", label_selector: %K8s.Selector{match_expressions: [%{"key" => "environment", "operator" => "In", "values" => ["qa", "prod"]}], match_labels: %{"app" => "nginx"}}, method: :get, name: :pods, path_params: [], verb: :get}
+      %K8s.Operation{data: nil, api_version: "v1", query_params: %{labelSelector: %K8s.Selector{match_expressions: [%{"key" => "environment", "operator" => "In", "values" => ["qa", "prod"]}], match_labels: %{"app" => "nginx"}}}, method: :get, name: :pods, path_params: [], verb: :get}
   """
 
   alias K8s.{Operation, Resource}
@@ -306,8 +306,8 @@ defmodule K8s.Selector do
 
   @spec merge(t | Operation.t(), t) :: t
   defp merge(%Operation{} = op, %__MODULE__{} = next) do
-    prev = op.label_selector || %__MODULE__{}
-    %Operation{op | label_selector: merge(prev, next)}
+    prev = Operation.get_query_param(op, :labelSelector) || %__MODULE__{}
+    Operation.put_query_param(op, :labelSelector, merge(prev, next))
   end
 
   defp merge(%__MODULE__{} = prev, %__MODULE__{} = next) do


### PR DESCRIPTION
- [Added] K8s.Operation `query_params` map.
- [Added] deprecation of HTTPoison options being passed to K8s.Client.Runner.base

Closes #66