### PR TITLE
Added GA for coveralls (issue #71)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,18 +31,17 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
       - run: mix dialyzer
-  # coverage:
-  #   name: Coverage
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v1.0.0
-  #     - uses: actions/setup-elixir@v1.0.0
-  #       with:
-  #         otp-version: 22.x
-  #         elixir-version: 1.9.x
-  #     - run: mix deps.get
-  #     - run: mix coveralls
-  #     - name: Coveralls
-  #       uses: coverallsapp/github-action@master
-  #       with:
-  #         github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: actions/setup-elixir@v1.0.0
+        with:
+          otp-version: 22.x
+          elixir-version: 1.9.x
+      - run: mix deps.get
+      - run: mix coveralls.github

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule K8s.MixProject do
       {:notion, "~> 0.2"},
       {:telemetry, ">=  0.4.0"},
 
-      # dev/test deps
+      # dev/test deps (e.g. code coverage)
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.20", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule K8s.MixProject do
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.20", only: :dev},
-      {:excoveralls, "~> 0.10", only: :test},
+      {:excoveralls, "~> 0.12", only: [:test]},
       {:mix_test_watch, "~> 0.8", only: :dev, runtime: false},
       {:stream_data, "~> 0.4", only: :test}
     ]


### PR DESCRIPTION
For issue #71 

This PR adds the code coverage check to the github pipeline main. It bases on the example of excoveralls.
I made use of the already provided `GITHUB_TOKEN` instead of `COVERALLS_REPO_TOKEN`.