### PR TITLE
Add server-side apply operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- `K8s.Client.apply/3` - Create a [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) operation
+
 ## [1.0.0] - 2021-07-19
+
 ### Added
+
 - `K8s.Resource.NamedList.access!/1` raises if item is missing
 - K8s.Operation.put_label_selector/2
 - K8s.Operation.get_label_selector/1
@@ -14,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - K8s.Operation now uses keyword lists for query_params instead of maps
 
 ### Changed
+
 - error tuples refactored away from binary and atom to exception modules
 - removed dialyzer exceptions
 - `K8s.Conn.from_file/2` now returns an ok or error tuple
@@ -28,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Middleware moved to K8s.Conn.Middleware
 
 ### Removed
+
 - K8s.Conn.lookup/1
 - config.exs based cluster registration is no longer supported, build K8s.Conn using K8s.Conn module
 - environment variable based cluster registration has been removed and may be moved to an external library
@@ -35,48 +43,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2] - 2020-07-31
 
 ### Added
+
 - Added auth `exec` support
 
 ## [0.5.1] - 2020-07-17
 
 ### Added
+
 - K8s.Operation struct `query_params` field
 - BasicAuth auth provider
 - Deprecated HTTPoison options being passed to K8s.Client.Runner.base
-- K8s.Operation.put_query_param/3 to add query parameters by key 
+- K8s.Operation.put_query_param/3 to add query parameters by key
 - K8s.Operation.get_query_param/3 to get a query parameter by key
 - DigitalOcean authentication
 - `K8s.Resource.NamedList.access/1` - Accessor for lists with named items (containers, env, ...) ([#82](https://github.com/coryodaniel/k8s/pull/82))
 
 ### Changed
+
 - Refactored old references to `cluster_name` to `conn`
 
 ## [0.5.0] - 2020-02-12
 
 ### Added
+
 - #42 Request middleware support
 - #43 Just in time discovery: K8s.Discovery
 - #44 Support for ad-hoc connections. K8s.Conn based functions. Build your own Conn at runtime or config mix/env vars. No more Cluster registry.
 - K8s.Resource.from_file/2 and K8s.Resource.all_from_file/2 - non-exception versions
 
 ### Removed
+
 - Boot time discovery K8s.Cluster.Discovery
 - K8s.Cluster.base_url/1
-- Remove K8s.Cluster*
+- Remove K8s.Cluster\*
 
 ## [0.4.0] - 2019-08-29
 
 ### Changed
+
 - Renamed `K8s.Conf` to `K8s.Conn`
 - Refactored `:conf` configuration key to `:conn`
 
 ## [0.3.2] - 2019-08-15
 
 ### Added
+
 - `K8s.Selector.match_expressions?/2` to check if a resource matches expressions
 - `K8s.Selector.match_labels?/2` to check if a resource matches labels
 
 ### Changed
+
 - `K8s.Resource` functions moved to submodule
 
 ## [0.3.1] - 2019-08-15

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -22,6 +22,11 @@ defmodule K8s.Client do
   @type path_param :: {:name, String.t()} | {:namespace, binary() | :all}
   @type path_params :: [path_param]
 
+  @mgmt_param_defaults %{
+    field_manager: "elixir",
+    force: true
+  }
+
   alias K8s.Operation
   alias K8s.Client.Runner.{Async, Base, Stream, Wait, Watch}
 
@@ -81,8 +86,8 @@ defmodule K8s.Client do
   """
   @spec apply(map(), keyword()) :: Operation.t()
   def apply(resource, mgmt_params \\ []) do
-    field_manager = Keyword.get(mgmt_params, :field_manager, "Elixir")
-    force = Keyword.get(mgmt_params, :force, true)
+    field_manager = Keyword.get(mgmt_params, :field_manager, @mgmt_param_defaults[:field_manager])
+    force = Keyword.get(mgmt_params, :force, @mgmt_param_defaults[:force])
     Operation.build(:apply, resource, field_manager: field_manager, force: force)
   end
 
@@ -112,8 +117,8 @@ defmodule K8s.Client do
         subresource,
         mgmt_params \\ []
       ) do
-    field_manager = Keyword.get(mgmt_params, :field_manager, "Elixir")
-    force = Keyword.get(mgmt_params, :force, true)
+    field_manager = Keyword.get(mgmt_params, :field_manager, @mgmt_param_defaults[:field_manager])
+    force = Keyword.get(mgmt_params, :force, @mgmt_param_defaults[:force])
 
     Operation.build(:apply, api_version, kind, path_params, subresource,
       field_manager: field_manager,

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -80,7 +80,8 @@ defmodule K8s.Client do
       }
   """
   @spec apply(map(), binary(), boolean()) :: Operation.t()
-  def apply(resource, field_manager, force) when is_binary(field_manager) do
+  def apply(resource, field_manager \\ "elixir", force \\ true)
+      when is_binary(field_manager) and is_boolean(force) do
     Operation.build(:apply, resource, field_manager: field_manager, force: force)
   end
 
@@ -88,37 +89,19 @@ defmodule K8s.Client do
   Returns a `PATCH` operation to server-side-apply the given subresource given a resource's details and a subresource map.
   """
   @spec apply(binary, binary | atom, Keyword.t(), map(), binary(), boolean()) :: Operation.t()
-  def apply(api_version, kind, path_params, subresource, field_manager, force),
-    do:
-      Operation.build(:apply, api_version, kind, path_params, subresource,
-        field_manager: field_manager,
-        force: force
-      )
-
-  @doc """
-  Returns a `PATCH` operation to server-side-apply the given subresource given a resource map and a subresource map.
-  """
-  @spec apply(map(), map(), binary(), boolean()) :: Operation.t()
   def apply(
-        %{
-          "apiVersion" => api_version,
-          "kind" => kind,
-          "metadata" => %{"namespace" => ns, "name" => name}
-        },
-        %{"kind" => subkind} = subresource,
-        field_manager,
-        force
-      ) do
-    Operation.build(
-      :apply,
-      api_version,
-      {kind, subkind},
-      [namespace: ns, name: name],
-      subresource,
-      field_manager: field_manager,
-      force: force
-    )
-  end
+        api_version,
+        kind,
+        path_params,
+        subresource,
+        field_manager \\ "elixir",
+        force \\ true
+      ),
+      do:
+        Operation.build(:apply, api_version, kind, path_params, subresource,
+          field_manager: field_manager,
+          force: force
+        )
 
   @doc """
   Returns a `GET` operation for a resource given a Kubernetes manifest. May be a partial manifest as long as it contains:

--- a/lib/k8s/client/dynamic_http_provider.ex
+++ b/lib/k8s/client/dynamic_http_provider.ex
@@ -8,6 +8,10 @@ defmodule K8s.Client.DynamicHTTPProvider do
   @behaviour K8s.Client.Provider
 
   @impl true
+  defdelegate headers(request_options), to: K8s.Client.HTTPProvider
+
+  @impl true
+  @deprecated "Use headers/1 insead."
   defdelegate headers(method, request_options), to: K8s.Client.HTTPProvider
 
   @impl true

--- a/lib/k8s/client/http_provider.ex
+++ b/lib/k8s/client/http_provider.ex
@@ -116,32 +116,23 @@ defmodule K8s.Client.HTTPProvider do
   Generates HTTP headers from `K8s.Conn.RequestOptions`
 
   * Adds `{"Accept", "application/json"}` to all requests.
-  * Adds `Content-Type` base on HTTP method.
+  * HTTP method is ignored.
 
   ## Examples
     Sets `Content-Type` to `application/merge-patch+json` for PATCH operations
       iex> opts = %K8s.Conn.RequestOptions{headers: [{"Authorization", "Basic AF"}]}
       ...> K8s.Client.HTTPProvider.headers(:patch, opts)
-      [{"Accept", "application/json"}, {"Content-Type", "application/merge-patch+json"}, {"Authorization", "Basic AF"}]
+      [{"Accept", "application/json"}, {"Authorization", "Basic AF"}]
 
     Sets `Content-Type` to `application/json` for all other operations
       iex> opts = %K8s.Conn.RequestOptions{headers: [{"Authorization", "Basic AF"}]}
       ...> K8s.Client.HTTPProvider.headers(:get, opts)
-      [{"Accept", "application/json"}, {"Content-Type", "application/json"}, {"Authorization", "Basic AF"}]
+      [{"Accept", "application/json"}, {"Authorization", "Basic AF"}]
   """
   @impl true
-  def headers(method, %RequestOptions{} = opts) do
-    defaults = [{"Accept", "application/json"}, content_type_header(method)]
+  def headers(_method, %RequestOptions{} = opts) do
+    defaults = [{"Accept", "application/json"}]
     defaults ++ opts.headers
-  end
-
-  @spec content_type_header(atom()) :: {binary(), binary()}
-  defp content_type_header(:patch) do
-    {"Content-Type", "application/merge-patch+json"}
-  end
-
-  defp content_type_header(_http_method) do
-    {"Content-Type", "application/json"}
   end
 
   @spec decode(binary, binary) :: map | list | nil

--- a/lib/k8s/client/provider.ex
+++ b/lib/k8s/client/provider.ex
@@ -7,6 +7,9 @@ defmodule K8s.Client.Provider do
   @type response_t :: success_t() | error_t()
 
   @doc "Generate headers for HTTP Requests"
+  @callback headers(K8s.Conn.RequestOptions.t()) :: keyword()
+
+  @doc "Deprecated! Use headers/1 instead"
   @callback headers(atom(), K8s.Conn.RequestOptions.t()) :: list({binary, binary})
 
   @doc "Perform HTTP Requests"

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -105,9 +105,9 @@ defmodule K8s.Client.Runner.Base do
 
     headers =
       case operation.verb do
-        :apply -> [{"Content-Type", "application/apply-patch+yaml"}]
-        :patch -> [{"Content-Type", "application/merge-patch+json"}]
-        _ -> [{"Content-Type", "application/json"}]
+        :patch -> ["Content-Type": "application/merge-patch+json"]
+        :apply -> ["Content-Type": "application/apply-patch+yaml"]
+        _ -> ["Content-Type": "application/json"]
       end
 
     operation_query_params = build_query_params(operation)

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -103,13 +103,20 @@ defmodule K8s.Client.Runner.Base do
   defp new_request(%Conn{} = conn, url, %Operation{} = operation, body, http_opts) do
     req = %Request{conn: conn, method: operation.method, body: body, url: url}
 
+    headers =
+      case operation.verb do
+        :apply -> [{"Content-Type", "application/apply-patch+yaml"}]
+        :patch -> [{"Content-Type", "application/merge-patch+json"}]
+        _ -> [{"Content-Type", "application/json"}]
+      end
+
     operation_query_params = build_query_params(operation)
     http_opts_params = Keyword.get(http_opts, :params, [])
     merged_params = Keyword.merge(operation_query_params, http_opts_params)
     http_opts_w_merged_params = Keyword.put(http_opts, :params, merged_params)
     updated_http_opts = Keyword.merge(req.opts, http_opts_w_merged_params)
 
-    %Request{req | opts: updated_http_opts}
+    %Request{req | opts: updated_http_opts, headers: headers}
   end
 
   @spec build_query_params(Operation.t()) :: keyword()

--- a/lib/k8s/discovery/driver/http.ex
+++ b/lib/k8s/discovery/driver/http.ex
@@ -58,7 +58,7 @@ defmodule K8s.Discovery.Driver.HTTP do
     case K8s.Conn.RequestOptions.generate(conn) do
       {:ok, request_options} ->
         url = Path.join(conn.url, path)
-        headers = conn.http_provider.headers(:get, request_options)
+        headers = conn.http_provider.headers(request_options)
         opts = [ssl: request_options.ssl_options]
         conn.http_provider.request(:get, url, "", headers, opts)
 

--- a/lib/k8s/middleware/request.ex
+++ b/lib/k8s/middleware/request.ex
@@ -7,7 +7,7 @@ defmodule K8s.Middleware.Request do
           method: atom(),
           url: String.t(),
           body: String.t() | map() | list(map()) | nil,
-          headers: keyword() | nil,
+          headers: Keyword.t() | nil,
           opts: Keyword.t() | nil
         }
 

--- a/lib/k8s/middleware/request.ex
+++ b/lib/k8s/middleware/request.ex
@@ -7,7 +7,7 @@ defmodule K8s.Middleware.Request do
           method: atom(),
           url: String.t(),
           body: String.t() | map() | list(map()) | nil,
-          headers: HTTPoison.Request.headers() | nil,
+          headers: keyword() | nil,
           opts: Keyword.t() | nil
         }
 

--- a/lib/k8s/middleware/request.ex
+++ b/lib/k8s/middleware/request.ex
@@ -7,7 +7,7 @@ defmodule K8s.Middleware.Request do
           method: atom(),
           url: String.t(),
           body: String.t() | map() | list(map()) | nil,
-          headers: Keyword.t() | nil,
+          headers: HTTPoison.Request.headers() | nil,
           opts: Keyword.t() | nil
         }
 

--- a/lib/k8s/middleware/request/initialize.ex
+++ b/lib/k8s/middleware/request/initialize.ex
@@ -6,10 +6,10 @@ defmodule K8s.Middleware.Request.Initialize do
   alias K8s.Middleware.Request
 
   @impl true
-  def call(%Request{conn: conn, method: method, headers: headers, opts: opts} = req) do
+  def call(%Request{conn: conn, headers: headers, opts: opts} = req) do
     with {:ok, request_options} <- K8s.Conn.RequestOptions.generate(conn) do
-      request_option_headers = conn.http_provider.headers(method, request_options)
-      updated_headers = headers ++ request_option_headers
+      request_option_headers = conn.http_provider.headers(request_options)
+      updated_headers = Keyword.merge(headers, request_option_headers)
       updated_opts = Keyword.merge([ssl: request_options.ssl_options], opts)
       updated_request = %Request{req | headers: updated_headers, opts: updated_opts}
       {:ok, updated_request}

--- a/lib/k8s/middleware/request/initialize.ex
+++ b/lib/k8s/middleware/request/initialize.ex
@@ -9,7 +9,7 @@ defmodule K8s.Middleware.Request.Initialize do
   def call(%Request{conn: conn, method: method, headers: headers, opts: opts} = req) do
     with {:ok, request_options} <- K8s.Conn.RequestOptions.generate(conn) do
       request_option_headers = conn.http_provider.headers(method, request_options)
-      updated_headers = Keyword.merge(headers, request_option_headers)
+      updated_headers = headers ++ request_option_headers
       updated_opts = Keyword.merge([ssl: request_options.ssl_options], opts)
       updated_request = %Request{req | headers: updated_headers, opts: updated_opts}
       {:ok, updated_request}

--- a/test/k8s/middleware/request/initialize_test.exs
+++ b/test/k8s/middleware/request/initialize_test.exs
@@ -7,7 +7,7 @@ defmodule K8s.Middleware.Request.InitializeTest do
 
     {:ok, %{headers: headers}} = K8s.Middleware.Request.Initialize.call(request)
 
-    assert headers == [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
+    assert headers == [{"Accept", "application/json"}]
   end
 
   test "initializes a HTTPoison options from K8s.Conn.RequestOptions" do

--- a/test/k8s/middleware/request/initialize_test.exs
+++ b/test/k8s/middleware/request/initialize_test.exs
@@ -3,11 +3,11 @@ defmodule K8s.Middleware.Request.InitializeTest do
 
   test "initializes a request headers from K8s.Conn.RequestOptions" do
     {:ok, conn} = K8s.Conn.from_file("./test/support/kube-config.yaml")
-    request = %K8s.Middleware.Request{conn: conn}
+    request = %K8s.Middleware.Request{conn: conn, headers: ["Content-Type": "application/json"]}
 
     {:ok, %{headers: headers}} = K8s.Middleware.Request.Initialize.call(request)
 
-    assert headers == [Accept: "application/json"]
+    assert headers == ["Content-Type": "application/json", Accept: "application/json"]
   end
 
   test "initializes a HTTPoison options from K8s.Conn.RequestOptions" do

--- a/test/k8s/middleware/request/initialize_test.exs
+++ b/test/k8s/middleware/request/initialize_test.exs
@@ -7,7 +7,7 @@ defmodule K8s.Middleware.Request.InitializeTest do
 
     {:ok, %{headers: headers}} = K8s.Middleware.Request.Initialize.call(request)
 
-    assert headers == [{"Accept", "application/json"}]
+    assert headers == [Accept: "application/json"]
   end
 
   test "initializes a HTTPoison options from K8s.Conn.RequestOptions" do


### PR DESCRIPTION
Implements apply the same way as kubectl does - by storing a json representation of the last applied resource in an annotation.

Since the apply has to check whether the resource already exists in the cluster, it requires the run() operation to be passed as a callback. Finally, this function applies the resource to the cluster directly by calling the run callback.

resolves #13 