### PR TITLE
Add K8s.Conn.Auth.Exec authentication strategy

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -70,7 +70,7 @@
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
         #
-        {Credo.Check.Design.TagTODO, [exit_status: 2]},
+        {Credo.Check.Design.TagTODO, [exit_status: 0]},
         {Credo.Check.Design.TagFIXME, []},
 
         #

--- a/.credo.exs
+++ b/.credo.exs
@@ -70,7 +70,7 @@
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
         #
-        {Credo.Check.Design.TagTODO, [exit_status: 0]},
+        {Credo.Check.Design.TagTODO, [exit_status: 2]},
         {Credo.Check.Design.TagFIXME, []},
 
         #

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,10 +1,12 @@
 # Authentication `K8s.Conn.Auth`
 
-`k8s` features pluggable authentication, but includes 3 strategies in the order of attempted application:
+`k8s` features pluggable authentication, but includes 5 strategies in the order of attempted application:
 
 * `K8s.Conn.Auth.Certificate` certificate based authentication
 * `K8s.Conn.Auth.Token` token based authentication
-* `K8s.Conn.Auth.AuthProvider` implements a Kubernetes config file's[`auth-provider`](https://banzaicloud.com/blog/kubeconfig-security/) functionality.
+* `K8s.Conn.Auth.AuthProvider` implements a Kubernetes config file's [`auth-provider`](https://banzaicloud.com/blog/kubeconfig-security/) functionality.
+* `K8s.Conn.Auth.Exec` implements a Kubernetes config file's [`exec`](https://banzaicloud.com/blog/kubeconfig-security/)
+ functionality.
 * `K8s.Conn.Auth.BasicAuth` username/password basic auth
 
 **A few notes first:**
@@ -45,6 +47,7 @@ This would result in authentication attemps in the following order:
 3. K8s.Conn.Auth.Certificate
 4. K8s.Conn.Auth.Token
 5. K8s.Conn.Auth.AuthProvider
-6. K8s.Conn.Auth.BasicAuth
+6. K8s.Conn.Auth.Exec
+7. K8s.Conn.Auth.BasicAuth
 
 For protocol and behavior implementation examples check out `Certificate`, `Token`, or `AuthProvider` [here](../lib/k8s/conn/auth/).

--- a/lib/k8s/conn.ex
+++ b/lib/k8s/conn.ex
@@ -17,6 +17,7 @@ defmodule K8s.Conn do
     K8s.Conn.Auth.Certificate,
     K8s.Conn.Auth.Token,
     K8s.Conn.Auth.AuthProvider,
+    K8s.Conn.Auth.Exec,
     K8s.Conn.Auth.BasicAuth
   ]
 

--- a/lib/k8s/conn/auth/exec.ex
+++ b/lib/k8s/conn/auth/exec.ex
@@ -98,16 +98,5 @@ defmodule K8s.Conn.Auth.Exec do
   defp parse_cmd_response(%{"kind" => "ExecCredential", "status" => %{"token" => token}}),
     do: {:ok, token}
 
-  #  # TODO: support clientKeyData and clientCertificateData
-  #  defp parse_cmd_response(
-  #         %{
-  #           "kind" => "ExecCredential",
-  #           "status" => %{
-  #             "clientCertificateData" => _certData,
-  #             "clientKeyData" => _keyData
-  #           }
-  #         }
-  #       ), do: {:error, {:exec_fail, "Unsupported ExecCredential"}}
-
   defp parse_cmd_response(_), do: {:error, {:exec_fail, "Unsupported ExecCredential"}}
 end

--- a/lib/k8s/conn/auth/exec.ex
+++ b/lib/k8s/conn/auth/exec.ex
@@ -56,6 +56,7 @@ defmodule K8s.Conn.Auth.Exec do
 
   def create(_, _), do: nil
 
+  defp format_env(nil), do: %{}
   defp format_env(env) when is_list(env), do: Enum.into(env, %{}, &format_env/1)
   defp format_env(%{"name" => key, "value" => value}), do: {key, value}
 

--- a/lib/k8s/conn/auth/exec.ex
+++ b/lib/k8s/conn/auth/exec.ex
@@ -1,0 +1,112 @@
+defmodule K8s.Conn.Auth.Exec do
+  @moduledoc """
+  Cluster authentication for kube configs using an `exec` section.
+
+  Useful for Kubernetes clusters running on AWS which use IAM authentication (eg. the `aws-iam-authenticator` binary).
+  An applicable kube config may look something like this:
+
+  ```
+  # ...
+  users:
+  - name: staging-user
+    user:
+      exec:
+        # API version to use when decoding the ExecCredentials resource. Required.
+        apiVersion: client.authentication.k8s.io/v1alpha1
+
+        # Command to execute. Required.
+        command: aws-iam-authenticator
+
+        # Arguments to pass when executing the plugin. Optional.
+        args:
+        - token
+        - -i
+        - staging
+
+        # Environment variables to set when executing the plugin. Optional.
+        env:
+        - name: "FOO"
+          value: "bar"
+  ```
+  """
+
+  @behaviour K8s.Conn.Auth
+  alias __MODULE__
+
+  defstruct [:command, :env, :args]
+
+  @type t :: %__MODULE__{
+          command: String.t(),
+          env: %{name: String.t(), value: String.t()},
+          args: list(String.t())
+        }
+
+  @impl true
+  def create(%{"exec" => %{"command" => command} = config}, _) do
+    # Optional:
+    args = Map.get(config, "args", [])
+    env = Map.get(config, "env", [])
+
+    %__MODULE__{
+      command: command,
+      env: format_env(env),
+      args: args
+    }
+  end
+
+  def create(_, _), do: nil
+
+  defp format_env(env) when is_list(env), do: Enum.into(env, %{}, &format_env/1)
+  defp format_env(%{"name" => key, "value" => value}), do: {key, value}
+
+  defimpl K8s.Conn.RequestOptions, for: __MODULE__ do
+    @doc "Generates HTTP Authorization options for auth-provider authentication"
+    @spec generate(Exec.t()) :: K8s.Conn.RequestOptions.generate_t()
+    def generate(%Exec{} = provider) do
+      with {:ok, token} <- Exec.generate_token(provider) do
+        {
+          :ok,
+          %K8s.Conn.RequestOptions{
+            headers: [{"Authorization", "Bearer #{token}"}],
+            ssl_options: []
+          }
+        }
+      end
+    end
+  end
+
+  @doc """
+  "Generate" a token using the `exec` config in kube config.
+  """
+  @spec generate_token(t) ::
+          {:ok, binary} | {:error, binary | atom, {:exec_fail, binary}}
+  def generate_token(config) do
+    with {cmd_response, 0} <- System.cmd(config.command, config.args, env: config.env),
+         {:ok, data} <- Jason.decode(cmd_response),
+         {:ok, token} when not is_nil(token) <- parse_cmd_response(data) do
+      {:ok, token}
+    else
+      {cmd_response, err_code} when is_binary(cmd_response) and is_integer(err_code) ->
+        {:error, {:exec_fail, cmd_response}}
+
+      error ->
+        error
+    end
+  end
+
+  defp parse_cmd_response(%{"kind" => "ExecCredential", "status" => %{"token" => token}}),
+    do: {:ok, token}
+
+  #  # TODO: support clientKeyData and clientCertificateData
+  #  defp parse_cmd_response(
+  #         %{
+  #           "kind" => "ExecCredential",
+  #           "status" => %{
+  #             "clientCertificateData" => _certData,
+  #             "clientKeyData" => _keyData
+  #           }
+  #         }
+  #       ), do: {:error, {:exec_fail, "Unsupported ExecCredential"}}
+
+  defp parse_cmd_response(_), do: {:error, {:exec_fail, "Unsupported ExecCredential"}}
+end

--- a/test/k8s/conn/auth/exec_test.exs
+++ b/test/k8s/conn/auth/exec_test.exs
@@ -52,6 +52,22 @@ defmodule K8s.Conn.Auth.ExecTest do
                args: []
              } = Exec.create(auth, nil)
     end
+
+    test "creates an exec struct with null env" do
+      auth = %{
+        "exec" => %{
+          "apiVersion" => "client.authentication.k8s.io/v1alpha1",
+          "command" => "aws-iam-authenticator",
+          "env" => nil
+        }
+      }
+
+      assert %Exec{
+               command: "aws-iam-authenticator",
+               env: %{},
+               args: []
+             } = Exec.create(auth, nil)
+    end
   end
 
   test "creates http request signing options" do

--- a/test/k8s/conn/auth/exec_test.exs
+++ b/test/k8s/conn/auth/exec_test.exs
@@ -1,0 +1,80 @@
+defmodule K8s.Conn.Auth.ExecTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias K8s.Conn
+  alias K8s.Conn.Auth.Exec
+
+  describe "create/2" do
+    test "creates an exec struct from exec data" do
+      auth = %{
+        "exec" => %{
+          "apiVersion" => "client.authentication.k8s.io/v1alpha1",
+          "command" => "aws-iam-authenticator"
+        }
+      }
+
+      assert %Exec{
+               command: "aws-iam-authenticator",
+               env: %{},
+               args: []
+             } = Exec.create(auth, nil)
+    end
+
+    test "creates an exec struct with function arguments" do
+      auth = %{
+        "exec" => %{
+          "apiVersion" => "client.authentication.k8s.io/v1alpha1",
+          "command" => "aws-iam-authenticator",
+          "args" => ["token", "-i", "staging"]
+        }
+      }
+
+      assert %Exec{
+               command: "aws-iam-authenticator",
+               env: %{},
+               args: ["token", "-i", "staging"]
+             } = Exec.create(auth, nil)
+    end
+
+    test "creates an exec struct with environment variables" do
+      auth = %{
+        "exec" => %{
+          "apiVersion" => "client.authentication.k8s.io/v1alpha1",
+          "command" => "aws-iam-authenticator",
+          "env" => [%{"name" => "FOO", "value" => "bar"}]
+        }
+      }
+
+      assert %Exec{
+               command: "aws-iam-authenticator",
+               env: %{"FOO" => "bar"},
+               args: []
+             } = Exec.create(auth, nil)
+    end
+  end
+
+  test "creates http request signing options" do
+    response = %{
+      "kind" => "ExecCredential",
+      "apiVersion" => "client.authentication.k8s.io/v1alpha1",
+      "spec" => %{},
+      "status" => %{
+        "expirationTimestamp" => "2020-07-15T08:36:10Z",
+        "token" => "foo"
+      }
+    }
+
+    provider = %Exec{
+      command: "echo",
+      args: [Jason.encode!(response)],
+      env: %{}
+    }
+
+    {:ok, %Conn.RequestOptions{headers: headers, ssl_options: ssl_options}} =
+      Conn.RequestOptions.generate(provider)
+
+    assert headers == [{"Authorization", "Bearer foo"}]
+    assert ssl_options == []
+  end
+end

--- a/test/k8s/conn_test.exs
+++ b/test/k8s/conn_test.exs
@@ -2,8 +2,7 @@ defmodule K8s.ConnTest do
   @moduledoc false
   use ExUnit.Case, async: true
   doctest K8s.Conn
-
-  alias K8s.Conn.Auth.{AuthProvider, Certificate, Token}
+  alias K8s.Conn.Auth.{AuthProvider, Certificate, Exec, Token}
   alias K8s.Conn.RequestOptions
 
   describe "list/0" do
@@ -84,6 +83,12 @@ defmodule K8s.ConnTest do
     test "loading an auth-provider" do
       config = K8s.Conn.from_file("test/support/kube-config.yaml", user: "auth-provider-user")
       assert %AuthProvider{} = config.auth
+      assert config.url == "https://localhost:6443"
+    end
+
+    test "loading an exec user" do
+      config = K8s.Conn.from_file("test/support/kube-config.yaml", user: "exec-user")
+      assert %Exec{} = config.auth
       assert config.url == "https://localhost:6443"
     end
   end

--- a/test/support/kube-config.yaml
+++ b/test/support/kube-config.yaml
@@ -63,3 +63,13 @@ users:
         expiry-key: '{.credential.token_expiry}'
         token-key: '{.credential.access_token}'
       name: gcp
+- name: exec-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: echo
+      args:
+        - "foo"
+      env:
+        - name: "FOO"
+          value: "bar"


### PR DESCRIPTION
I've finally found some time to work on elixir-kubernetes things again, so here's a pull request for the exec auth module as previously discussed in #5, with some updates:

* added it as an option in the default list of authentication providers
* added some basic tests and updated some of the docs

I also tested it again with our EKS cluster and the `aws-iam-authenticator` (still working well!).

This is still missing support for `clientKeyData` and `clientCertificateData` -- is this something we should attempt to add or would it be okay to commit/merge without? Since I'm not sure how to test those I'd rather leave it for someone else...

Closes #5.