### PR TITLE
Per cluster http providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Unreleased
+### Added
+- Per connection http provider configuration
+
+### Changed
+- deprecated K8s.http_provider/0 for K8s.default_http_provider/0
 
 ## [0.5.2] - 2020-07-31
 

--- a/lib/k8s.ex
+++ b/lib/k8s.ex
@@ -3,7 +3,12 @@ defmodule K8s do
 
   @doc false
   @spec http_provider() :: module()
-  def http_provider do
+  @deprecated "Call K8s.default_http_provider/0 instead"
+  def http_provider, do: default_http_provider()
+  
+  @doc "Returns the default HTTP Provider"
+  @spec http_provider() :: module()
+  def default_http_provider do
     Application.get_env(:k8s, :http_provider, K8s.Client.HTTPProvider)
   end
 end

--- a/lib/k8s.ex
+++ b/lib/k8s.ex
@@ -5,10 +5,55 @@ defmodule K8s do
   @spec http_provider() :: module()
   @deprecated "Call K8s.default_http_provider/0 instead"
   def http_provider, do: default_http_provider()
-  
+
   @doc "Returns the default HTTP Provider"
-  @spec http_provider() :: module()
+  @spec default_http_provider() :: module()
   def default_http_provider do
     Application.get_env(:k8s, :http_provider, K8s.Client.HTTPProvider)
+  end
+
+  @doc """
+  Returns the _default_ driver for discovery.
+
+  Each `K8s.Conn` can have its own driver set. If unset, this value will be used.
+
+  Defaults to `K8s.Discovery.Driver.HTTP`
+
+  ## Example mix config
+  In the example below `dev` and `test` clusters will use the File driver, while `prod` will use the HTTP driver.
+  ```elixir
+  use Mix.Config
+
+  config :k8s,
+    discovery_driver: K8s.Discovery.Driver.File,
+    discovery_opts: [config: "test/support/discovery/example.json"],
+
+    clusters: %{
+      test: %{
+        conn: "test/support/kube-config.yaml"
+      },
+      dev: %{
+        conn: "test/support/kube-config.yaml"
+      },
+      prod: %{
+        conn: "test/support/kube-config.yaml",
+        conn_opts: [
+          discovery_driver: K8s.Discovery.Driver.HTTP
+        ]
+      }
+    }
+  ```
+  """
+  @spec default_discovery_driver() :: module()
+  def default_discovery_driver do
+    Application.get_env(:k8s, :discovery_driver, K8s.Discovery.Driver.HTTP)
+  end
+
+  @doc """
+  Returns default opts for the discovery driver. This is also configurable per `K8s.Conn`
+  """
+  @spec default_discovery_opts() :: Keyword.t()
+  def default_discovery_opts do
+    Application.get_env(:k8s, :discovery_opts, [])
   end
 end

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -127,11 +127,13 @@ defmodule K8s.Client.Runner.Base do
     %Request{req | opts: http_opts, url: url}
   end
 
-  @spec maybe_get_deprecated_label_selector(K8s.Selector.t() | nil, K8s.Selector.t() | nil) :: K8s.Selector.t() | nil
+  @spec maybe_get_deprecated_label_selector(K8s.Selector.t() | nil, K8s.Selector.t() | nil) ::
+          K8s.Selector.t() | nil
   defp maybe_get_deprecated_label_selector(new_label_selector, nil), do: new_label_selector
-  
+
   @deprecated "K8s.Operation label_selector is deprecated. Use K8s.Selector functions instead."
-  defp maybe_get_deprecated_label_selector(nil, deprecated_label_selector), do: deprecated_label_selector
+  defp maybe_get_deprecated_label_selector(nil, deprecated_label_selector),
+    do: deprecated_label_selector
 
   @spec merge_deprecated_params(map(), nil | map()) :: map()
   defp merge_deprecated_params(op_params, nil), do: op_params

--- a/lib/k8s/discovery.ex
+++ b/lib/k8s/discovery.ex
@@ -35,48 +35,11 @@ defmodule K8s.Discovery do
     end
   end
 
-  @doc """
-  Override the _default_ driver for discovery.
-
-  Each `K8s.Conn` can have its own driver set. If unset, this value will be used.
-
-  Defaults to `K8s.Discovery.Driver.HTTP`
-
-  ## Example mix config
-  In the example below `dev` and `test` clusters will use the File driver, while `prod` will use the HTTP driver.
-  ```elixir
-  use Mix.Config
-
-  config :k8s,
-    discovery_driver: K8s.Discovery.Driver.File,
-    discovery_opts: [config: "test/support/discovery/example.json"],
-
-    clusters: %{
-      test: %{
-        conn: "test/support/kube-config.yaml"
-      },
-      dev: %{
-        conn: "test/support/kube-config.yaml"
-      },
-      prod: %{
-        conn: "test/support/kube-config.yaml",
-        conn_opts: [
-          discovery_driver: K8s.Discovery.Driver.HTTP
-        ]
-      }
-    }
-  ```
-  """
   @spec default_driver() :: module()
-  def default_driver do
-    Application.get_env(:k8s, :discovery_driver, K8s.Discovery.Driver.HTTP)
-  end
+  @deprecated "Use K8s.default_discovery_driver/0 instead"
+  def default_driver, do: K8s.default_discovery_driver()
 
-  @doc """
-  Override default opts for the discovery driver. This is also configurable per `K8s.Conn`
-  """
+  @deprecated "Use K8s.default_discovery_opts/0 instead"
   @spec default_opts() :: Keyword.t()
-  def default_opts do
-    Application.get_env(:k8s, :discovery_opts, [])
-  end
+  def default_opts, do: K8s.default_discovery_opts()
 end

--- a/lib/k8s/discovery/driver/file.ex
+++ b/lib/k8s/discovery/driver/file.ex
@@ -71,8 +71,8 @@ defmodule K8s.Discovery.Driver.File do
 
   @spec default_opts() :: Keyword.t()
   defp default_opts do
-    case K8s.Discovery.default_driver() do
-      __MODULE__ -> K8s.Discovery.default_opts()
+    case K8s.default_discovery_driver() do
+      __MODULE__ -> K8s.default_discovery_opts()
       _ -> []
     end
   end

--- a/lib/k8s/discovery/driver/http.ex
+++ b/lib/k8s/discovery/driver/http.ex
@@ -58,9 +58,9 @@ defmodule K8s.Discovery.Driver.HTTP do
     case K8s.Conn.RequestOptions.generate(conn) do
       {:ok, request_options} ->
         url = Path.join(conn.url, path)
-        headers = K8s.http_provider().headers(:get, request_options)
+        headers = K8s.default_http_provider().headers(:get, request_options)
         opts = [ssl: request_options.ssl_options]
-        K8s.http_provider().request(:get, url, "", headers, opts)
+        K8s.default_http_provider().request(:get, url, "", headers, opts)
 
       error ->
         error

--- a/lib/k8s/middleware/request/initialize.ex
+++ b/lib/k8s/middleware/request/initialize.ex
@@ -8,7 +8,7 @@ defmodule K8s.Middleware.Request.Initialize do
   @impl true
   def call(%Request{conn: conn, method: method, headers: headers, opts: opts} = req) do
     with {:ok, request_options} <- K8s.Conn.RequestOptions.generate(conn) do
-      request_option_headers = K8s.default_http_provider().headers(method, request_options)
+      request_option_headers = conn.http_provider.headers(method, request_options)
       updated_headers = Keyword.merge(headers, request_option_headers)
       updated_opts = Keyword.merge([ssl: request_options.ssl_options], opts)
       updated_request = %Request{req | headers: updated_headers, opts: updated_opts}

--- a/lib/k8s/middleware/request/initialize.ex
+++ b/lib/k8s/middleware/request/initialize.ex
@@ -8,7 +8,7 @@ defmodule K8s.Middleware.Request.Initialize do
   @impl true
   def call(%Request{conn: conn, method: method, headers: headers, opts: opts} = req) do
     with {:ok, request_options} <- K8s.Conn.RequestOptions.generate(conn) do
-      request_option_headers = K8s.http_provider().headers(method, request_options)
+      request_option_headers = K8s.default_http_provider().headers(method, request_options)
       updated_headers = Keyword.merge(headers, request_option_headers)
       updated_opts = Keyword.merge([ssl: request_options.ssl_options], opts)
       updated_request = %Request{req | headers: updated_headers, opts: updated_opts}


### PR DESCRIPTION
Refactor connections to support configuring http providers and defaulting to `K8s.Client.HTTPProvider`. This is necessary to override the provider for integration tests (#87).