### PR TITLE
Docs: adding DynamicHTTPProvider to test_helpers.exs

### DIFF
--- a/guides/testing.md
+++ b/guides/testing.md
@@ -37,6 +37,12 @@ To enable the dynamic HTTP provider it must be turned on in your `config.exs`:
 config :k8s, http_provider: K8s.Client.DynamicHTTPProvider
 ```
 
+You must also start it before tests are run, usually in `test/test_helper.exs`:
+
+```elixir
+K8s.Client.DynamicHTTPProvider.start_link(nil)
+```
+
 ```elixir
 defmodule MyApp.ResourceTest do
   use ExUnit.Case, async: true


### PR DESCRIPTION
Was following the [testing guide](https://hexdocs.pm/k8s/testing.html) and getting this error:

```
** (exit) exited in: GenServer.call(K8s.Client.DynamicHTTPProvider, {:register, #PID<0.531.0>, Tribes.DeployTest.K8sMock}, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```

After comparing my files I realized I needed to add a line to `test_helper.exs` to make it work.