### PR TITLE
K8s.Client.create - support generateName

### DIFF
--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -269,11 +269,28 @@ defmodule K8s.Client do
     Operation.build(:create, api_version, kind, [namespace: ns, name: name], resource)
   end
 
+  def create(
+        %{
+          "apiVersion" => api_version,
+          "kind" => kind,
+          "metadata" => %{"namespace" => ns, "generateName" => _}
+        } = resource
+      ) do
+    Operation.build(:create, api_version, kind, [namespace: ns], resource)
+  end
+
   # Support for creating resources that are cluster-scoped, like Namespaces.
   def create(
         %{"apiVersion" => api_version, "kind" => kind, "metadata" => %{"name" => name}} = resource
       ) do
     Operation.build(:create, api_version, kind, [name: name], resource)
+  end
+
+  def create(
+        %{"apiVersion" => api_version, "kind" => kind, "metadata" => %{"generateName" => _}} =
+          resource
+      ) do
+    Operation.build(:create, api_version, kind, [], resource)
   end
 
   @doc """

--- a/test/k8s/client_test.exs
+++ b/test/k8s/client_test.exs
@@ -1,4 +1,40 @@
 defmodule K8s.ClientTest do
   use ExUnit.Case, async: true
   doctest K8s.Client
+
+  test "generateName with create/1" do
+    job = %{
+      "apiVersion" => "batch/v1",
+      "kind" => "Job",
+      "metadata" => %{
+        "namespace" => "default",
+        "generateName" => "hello-"
+      },
+      "spec" => %{
+        "template" => %{
+          "spec" => %{
+            "containers" => [
+              %{
+                "name" => "hello",
+                "image" => "busybox",
+                "args" => ["/bin/sh", "-c", "echo Hello, world"]
+              }
+            ],
+            "restartPolicy" => "OnFailure"
+          }
+        }
+      }
+    }
+
+    assert %K8s.Operation{
+             api_version: "batch/v1",
+             data: ^job,
+             label_selector: nil,
+             method: :post,
+             name: "Job",
+             path_params: [namespace: "default"],
+             query_params: %{},
+             verb: :create
+           } = K8s.Client.create(job)
+  end
 end

--- a/test/k8s/client_test.exs
+++ b/test/k8s/client_test.exs
@@ -37,4 +37,25 @@ defmodule K8s.ClientTest do
              verb: :create
            } = K8s.Client.create(job)
   end
+
+  test "generateName with create/1 for cluster scoped resources" do
+    ns = %{
+      "apiVersion" => "v1",
+      "kind" => "Namespace",
+      "metadata" => %{
+        "generateName" => "hello-"
+      }
+    }
+
+    assert %K8s.Operation{
+             api_version: "v1",
+             data: ^ns,
+             label_selector: nil,
+             method: :post,
+             name: "Namespace",
+             path_params: [],
+             query_params: %{},
+             verb: :create
+           } = K8s.Client.create(ns)
+  end
 end


### PR DESCRIPTION
Fixes #102.

@coryodaniel Thoughts on tests for this?  Saw `K8s.Client` is using `doctest`, I can add an example to the docs, but it might get quite long