### PR TITLE
add field selector support to K8s.Selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ k8s-*.tar
 
 # Ignore local k8s config/integration test files
 integration.yaml
+
+# editor configs
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "files.autoSave": "onFocusChange",
+    "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "files.autoSave": "onFocusChange",
-    "editor.formatOnSave": true
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- `K8s.Selector.field/N` and `K8s.Selector.field_not/N` - Support for field selectors ([#117](https://github.com/coryodaniel/k8s/pull/117))
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [1.1.10] - 2022-10-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `K8s.Selector.field/N` and `K8s.Selector.field_not/N` - Support for field selectors ([#117](https://github.com/coryodaniel/k8s/pull/117))
+- `K8s.Selector.label_not/N`, `K8s.Selector.field/N` and `K8s.Selector.field_not/N` - Support for field selectors ([#117](https://github.com/coryodaniel/k8s/pull/117))
 
 <!--------------------- Don't add new entries after this line --------------------->
 

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -123,12 +123,11 @@ defmodule K8s.Client.Runner.Base do
 
   @spec build_query_params(Operation.t()) :: keyword()
   defp build_query_params(%Operation{} = operation) do
-    label_selector = Operation.get_label_selector(operation)
-    field_selector = Operation.get_field_selector(operation)
+    selector = Operation.get_selector(operation)
 
     Keyword.merge(operation.query_params,
-      labelSelector: K8s.Selector.labels_to_s(label_selector),
-      fieldSelector: K8s.Selector.fields_to_s(field_selector)
+      labelSelector: K8s.Selector.labels_to_s(selector),
+      fieldSelector: K8s.Selector.fields_to_s(selector)
     )
   end
 end

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -124,6 +124,11 @@ defmodule K8s.Client.Runner.Base do
   @spec build_query_params(Operation.t()) :: keyword()
   defp build_query_params(%Operation{} = operation) do
     label_selector = Operation.get_label_selector(operation)
-    Keyword.merge(operation.query_params, labelSelector: K8s.Selector.to_s(label_selector))
+    field_selector = Operation.get_field_selector(operation)
+
+    Keyword.merge(operation.query_params,
+      labelSelector: K8s.Selector.labels_to_s(label_selector),
+      fieldSelector: K8s.Selector.fields_to_s(field_selector)
+    )
   end
 end

--- a/lib/k8s/operation.ex
+++ b/lib/k8s/operation.ex
@@ -6,8 +6,7 @@ defmodule K8s.Operation do
   @derive {Jason.Encoder, except: [:path_params]}
 
   @allow_http_body [:put, :patch, :post]
-  @label_selector :labelSelector
-  @field_selector :fieldSelector
+  @selector :labelSelector
   @verb_map %{
     list_all_namespaces: :get,
     list: :get,
@@ -196,48 +195,48 @@ defmodule K8s.Operation do
           {:ok, String.t()} | {:error, Error.t()}
   def to_path(%Operation{} = operation), do: Operation.Path.build(operation)
 
+  @deprecated "Use put_selector/2"
+  @spec put_label_selector(Operation.t(), Selector.t()) :: Operation.t()
+  defdelegate put_label_selector(op, selector), to: __MODULE__, as: :put_selector
+
   @doc """
   Puts a `K8s.Selector` on the operation.
 
   ## Examples
       iex> operation = %K8s.Operation{}
       ...> selector = K8s.Selector.label({"component", "redis"})
-      ...> K8s.Operation.put_label_selector(operation, selector)
+      ...> K8s.Operation.put_selector(operation, selector)
       %K8s.Operation{
         query_params: [
           labelSelector: %K8s.Selector{
             match_expressions: [],
-            match_labels: %{"component" => "redis"}
+            match_labels: %{"component" => {"=", "redis"}}
           }
         ]
       }
   """
-  @spec put_label_selector(Operation.t(), Selector.t()) :: Operation.t()
-  def put_label_selector(%Operation{} = op, %Selector{} = selector),
-    do: put_query_param(op, @label_selector, selector)
+  @spec put_selector(Operation.t(), Selector.t()) :: Operation.t()
+  def put_selector(%Operation{} = op, %Selector{} = selector),
+    do: put_query_param(op, @selector, selector)
 
-  @spec put_field_selector(Operation.t(), Selector.t()) :: Operation.t()
-  def put_field_selector(%Operation{} = op, %Selector{} = selector),
-    do: put_query_param(op, @field_selector, selector)
+  @deprecated "Use get_selector/1"
+  @spec get_label_selector(K8s.Operation.t()) :: K8s.Selector.t()
+  defdelegate get_label_selector(operation), to: __MODULE__, as: :get_selector
 
   @doc """
   Gets a `K8s.Selector` on the operation.
 
   ## Examples
       iex> operation = %K8s.Operation{query_params: [labelSelector: K8s.Selector.label({"component", "redis"})]}
-      ...> K8s.Operation.get_label_selector(operation)
+      ...> K8s.Operation.get_selector(operation)
       %K8s.Selector{
         match_expressions: [],
-        match_labels: %{"component" => "redis"}
+        match_labels: %{"component" => {"=", "redis"}}
       }
   """
-  @spec get_label_selector(K8s.Operation.t()) :: K8s.Selector.t()
-  def get_label_selector(%Operation{query_params: params}),
-    do: Keyword.get(params, @label_selector, %K8s.Selector{})
-
-  @spec get_field_selector(K8s.Operation.t()) :: K8s.Selector.t()
-  def get_field_selector(%Operation{query_params: params}),
-    do: Keyword.get(params, @field_selector, %K8s.Selector{})
+  @spec get_selector(K8s.Operation.t()) :: K8s.Selector.t()
+  def get_selector(%Operation{query_params: params}),
+    do: Keyword.get(params, @selector, %K8s.Selector{})
 
   @doc """
   Add a query param to an operation

--- a/lib/k8s/operation.ex
+++ b/lib/k8s/operation.ex
@@ -7,6 +7,7 @@ defmodule K8s.Operation do
 
   @allow_http_body [:put, :patch, :post]
   @label_selector :labelSelector
+  @field_selector :fieldSelector
   @verb_map %{
     list_all_namespaces: :get,
     list: :get,
@@ -215,6 +216,10 @@ defmodule K8s.Operation do
   def put_label_selector(%Operation{} = op, %Selector{} = selector),
     do: put_query_param(op, @label_selector, selector)
 
+  @spec put_field_selector(Operation.t(), Selector.t()) :: Operation.t()
+  def put_field_selector(%Operation{} = op, %Selector{} = selector),
+    do: put_query_param(op, @field_selector, selector)
+
   @doc """
   Gets a `K8s.Selector` on the operation.
 
@@ -229,6 +234,10 @@ defmodule K8s.Operation do
   @spec get_label_selector(K8s.Operation.t()) :: K8s.Selector.t()
   def get_label_selector(%Operation{query_params: params}),
     do: Keyword.get(params, @label_selector, %K8s.Selector{})
+
+  @spec get_field_selector(K8s.Operation.t()) :: K8s.Selector.t()
+  def get_field_selector(%Operation{query_params: params}),
+    do: Keyword.get(params, @field_selector, %K8s.Selector{})
 
   @doc """
   Add a query param to an operation

--- a/lib/k8s/selector.ex
+++ b/lib/k8s/selector.ex
@@ -221,11 +221,11 @@ defmodule K8s.Selector do
   `fieldSelector` helper that creates a composable `K8s.Selector`.
 
   ## Examples
-  iex> K8s.Selector.field({"metadata.namespace", "default"})
-  %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}}}
+      iex> K8s.Selector.field({"metadata.namespace", "default"})
+      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}}}
 
-  iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
-  %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
+      iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
+      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
   """
 
   @spec field({binary | atom, binary} | map) :: t()
@@ -239,11 +239,11 @@ defmodule K8s.Selector do
   `fieldSelector` helper that creates a composable `K8s.Selector`.
 
   ## Examples
-  iex> K8s.Selector.field({"metadata.namespace", "default"})
-  %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}}}
+      iex> K8s.Selector.field({"metadata.namespace", "default"})
+      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}}}
 
-  iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
-  %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
+      iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
+      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
   """
   def field(%{} = selector_or_operation, field),
     do: merge(selector_or_operation, field(field), :field)
@@ -252,11 +252,11 @@ defmodule K8s.Selector do
   `fieldSelector` helper that creates a composable `K8s.Selector`.
 
   ## Examples
-  iex> K8s.Selector.field_not({"metadata.namespace", "default"})
-  %K8s.Selector{match_fields: %{"metadata.namespace" => {"!=", "default"}}}
+      iex> K8s.Selector.field_not({"metadata.namespace", "default"})
+      %K8s.Selector{match_fields: %{"metadata.namespace" => {"!=", "default"}}}
 
-  iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
-  %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
+      iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
+      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
   """
   @spec field_not({binary | atom, binary} | map) :: t()
   def field_not({k, v}),
@@ -388,13 +388,19 @@ defmodule K8s.Selector do
   end
 
   @doc """
+  Serializes a `K8s.Selector` to a `labelSelector` query string. See `labels_to_s/1`
+  """
+  @spec to_s(t) :: binary()
+  defdelegate to_s(selector), to: __MODULE__, as: :labels_to_s
+
+  @doc """
   Serializes a `K8s.Selector` to a `labelSelector` query string.
 
   ## Examples
 
-    iex> selector = K8s.Selector.label({"component", "redis"})
-    ...> K8s.Selector.labels_to_s(selector)
-    "component=redis"
+      iex> selector = K8s.Selector.label({"component", "redis"})
+      ...> K8s.Selector.labels_to_s(selector)
+      "component=redis"
   """
   @spec labels_to_s(t) :: binary()
   def labels_to_s(%K8s.Selector{match_labels: labels, match_expressions: expr}) do
@@ -407,9 +413,9 @@ defmodule K8s.Selector do
 
   ## Examples
 
-  iex> selector = K8s.Selector.field({"status.phase", "Running"})
-  ...> K8s.Selector.fields_to_s(selector)
-  "status.phase=Running"
+      iex> selector = K8s.Selector.field({"status.phase", "Running"})
+      ...> K8s.Selector.fields_to_s(selector)
+      "status.phase=Running"
   """
   @spec fields_to_s(t) :: binary()
   def fields_to_s(%K8s.Selector{match_fields: fields}) do
@@ -423,15 +429,15 @@ defmodule K8s.Selector do
 
   ## Examples
 
-    iex> selector = %{
-    ...>   "matchLabels" => %{"component" => "redis"},
-    ...>   "matchExpressions" => [
-    ...>     %{"operator" => "In", "key" => "tier", "values" => ["cache"]},
-    ...>     %{"operator" => "NotIn", "key" => "environment", "values" => ["dev"]}
-    ...>   ]
-    ...> }
-    ...> K8s.Selector.parse(selector)
-    %K8s.Selector{match_labels: %{"component" => "redis"}, match_expressions: [%{"operator" => "In", "key" => "tier", "values" => ["cache"]},%{"operator" => "NotIn", "key" => "environment", "values" => ["dev"]}]}
+      iex> selector = %{
+      ...>   "matchLabels" => %{"component" => "redis"},
+      ...>   "matchExpressions" => [
+      ...>     %{"operator" => "In", "key" => "tier", "values" => ["cache"]},
+      ...>     %{"operator" => "NotIn", "key" => "environment", "values" => ["dev"]}
+      ...>   ]
+      ...> }
+      ...> K8s.Selector.parse(selector)
+      %K8s.Selector{match_labels: %{"component" => "redis"}, match_expressions: [%{"operator" => "In", "key" => "tier", "values" => ["cache"]},%{"operator" => "NotIn", "key" => "environment", "values" => ["dev"]}]}
   """
   @spec parse(map) :: t
   def parse(%{"spec" => %{"selector" => selector}}), do: parse(selector)
@@ -473,15 +479,15 @@ defmodule K8s.Selector do
   Returns a `fieldSelector` query string value for a set of field selectors.
 
   ## Examples
-  Builds a query string for a single field (`kubectl get pods --field-selector status.phase=Running`):
+    Builds a query string for a single field (`kubectl get pods --field-selector status.phase=Running`):
 
-  iex> K8s.Selector.serialize_match_fields(%{"status.phase" => {"=", "Running"}})
-  ["status.phase=Running"]
+      iex> K8s.Selector.serialize_match_fields(%{"status.phase" => {"=", "Running"}})
+      ["status.phase=Running"]
 
-  Builds a query string for multiple fields (`kubectl get pods --field-selector status.phase=Running,metadata.namespace!=default`):
+    Builds a query string for multiple fields (`kubectl get pods --field-selector status.phase=Running,metadata.namespace!=default`):
 
-  iex> K8s.Selector.serialize_match_fields(%{"metadata.namespace" => {"!=", "default"}, "status.phase" => {"=", "Running"}})
-  ["metadata.namespace!=default", "status.phase=Running"]
+      iex> K8s.Selector.serialize_match_fields(%{"metadata.namespace" => {"!=", "default"}, "status.phase" => {"=", "Running"}})
+      ["metadata.namespace!=default", "status.phase=Running"]
   """
   @spec serialize_match_fields(map()) :: list(binary())
   def serialize_match_fields(%{} = fields) do

--- a/lib/k8s/selector.ex
+++ b/lib/k8s/selector.ex
@@ -235,16 +235,6 @@ defmodule K8s.Selector do
   def field(fields) when is_map(fields),
     do: field_selector_from_map(fields, "=")
 
-  @doc """
-  `fieldSelector` helper that creates a composable `K8s.Selector`.
-
-  ## Examples
-      iex> K8s.Selector.field({"metadata.namespace", "default"})
-      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}}}
-
-      iex> K8s.Selector.field(%{"metadata.namespace" => "default", "status.phase" => "Running"})
-      %K8s.Selector{match_fields: %{"metadata.namespace" => {"=", "default"}, "status.phase" => {"=", "Running"}}}
-  """
   def field(%{} = selector_or_operation, field),
     do: merge(selector_or_operation, field(field), :field)
 
@@ -262,8 +252,10 @@ defmodule K8s.Selector do
   def field_not({k, v}),
     do: %K8s.Selector{match_fields: %{k => {"!=", v}}}
 
-  @spec field_not({binary | atom, binary} | map) :: t()
   def field_not(fields) when is_map(fields), do: field_selector_from_map(fields, "!=")
+
+  def field_not(%{} = selector_or_operation, field),
+    do: merge(selector_or_operation, field_not(field), :field)
 
   @doc """
   `matchLabels` helper that creates a composable `K8s.Selector`.

--- a/lib/k8s/selector.ex
+++ b/lib/k8s/selector.ex
@@ -381,10 +381,19 @@ defmodule K8s.Selector do
   end
 
   @doc """
-  Serializes a `K8s.Selector` to a `labelSelector` query string. See `labels_to_s/1`
+  Serializes `K8s.Selector` into a keyword list containing the `labelSelector` and `fieldSelector` query strings.
+
+  ## Examples
+
+      iex> selector = K8s.Selector.label({"component", "redis"})
+      ...> selector = K8s.Selector.field(selector, {"status.phase", "Running"})
+      ...> K8s.Selector.to_s(selector)
+      [field_selector: "status.phase=Running", label_selector: "component=redis"]
   """
-  @spec to_s(t) :: binary()
-  defdelegate to_s(selector), to: __MODULE__, as: :labels_to_s
+  @spec to_s(t) :: keyword()
+  def to_s(selector) do
+    [field_selector: fields_to_s(selector), label_selector: labels_to_s(selector)]
+  end
 
   @doc """
   Serializes a `K8s.Selector` to a `labelSelector` query string.

--- a/lib/k8s/selector.ex
+++ b/lib/k8s/selector.ex
@@ -235,6 +235,7 @@ defmodule K8s.Selector do
   def field(fields) when is_map(fields),
     do: field_selector_from_map(fields, "=")
 
+  @spec field(map(), {binary | atom, binary}) :: t()
   def field(%{} = selector_or_operation, field),
     do: merge(selector_or_operation, field(field), :field)
 
@@ -254,6 +255,7 @@ defmodule K8s.Selector do
 
   def field_not(fields) when is_map(fields), do: field_selector_from_map(fields, "!=")
 
+  @spec field_not(map(), {binary | atom, binary}) :: t()
   def field_not(%{} = selector_or_operation, field),
     do: merge(selector_or_operation, field_not(field), :field)
 
@@ -360,7 +362,6 @@ defmodule K8s.Selector do
     Operation.put_label_selector(op, merged_selector)
   end
 
-  @spec merge(selector_or_operation_t, t, atom) :: selector_or_operation_t
   defp merge(%Operation{} = op, %__MODULE__{} = next, :field) do
     prev = Operation.get_field_selector(op)
     merged_selector = merge(prev, next, :label)
@@ -553,6 +554,7 @@ defmodule K8s.Selector do
 
   defp serialize_match_expression(%{"operator" => "DoesNotExist", "key" => key}), do: "!#{key}"
 
+  @spec field_selector_from_map(map(), String.t()) :: t()
   defp field_selector_from_map(fields, op) do
     match_fields =
       fields

--- a/test/k8s/client/runner/base_test.exs
+++ b/test/k8s/client/runner/base_test.exs
@@ -44,7 +44,18 @@ defmodule K8s.Client.Runner.BaseTest do
           _body,
           _headers,
           ssl: _ssl,
-          params: [labelSelector: "app=nginx"]
+          params: [labelSelector: "app=nginx", fieldSelector: ""]
+        ) do
+      render(nil)
+    end
+
+    def request(
+          :get,
+          @base_url <> "/api/v1/pods",
+          _body,
+          _headers,
+          ssl: _ssl,
+          params: [labelSelector: "", fieldSelector: "status.phase=Running"]
         ) do
       render(nil)
     end
@@ -68,10 +79,18 @@ defmodule K8s.Client.Runner.BaseTest do
   end
 
   describe "run/2" do
-    test "running an operation with a K8s.Selector set", %{conn: conn} do
+    test "running an operation with a label K8s.Selector set", %{conn: conn} do
       operation =
         Client.list("v1", :pods)
         |> K8s.Selector.label({"app", "nginx"})
+
+      assert {:ok, _} = Base.run(conn, operation)
+    end
+
+    test "running an operation with a field K8s.Selector set", %{conn: conn} do
+      operation =
+        Client.list("v1", :pods)
+        |> K8s.Selector.field({"status.phase", "Running"})
 
       assert {:ok, _} = Base.run(conn, operation)
     end

--- a/test/k8s/client/runner/stream_integration_test.exs
+++ b/test/k8s/client/runner/stream_integration_test.exs
@@ -27,7 +27,7 @@ defmodule K8s.Client.Runner.StreamIntegrationTest do
 
     selector = K8s.Selector.label(labels)
     operation = K8s.Client.list("v1", "Pod", namespace: "default")
-    operation = K8s.Operation.put_label_selector(operation, selector)
+    operation = K8s.Operation.put_selector(operation, selector)
     assert {:ok, stream} = K8s.Client.Runner.Stream.run(conn, operation)
 
     resources =

--- a/test/k8s/client/runner/stream_test.exs
+++ b/test/k8s/client/runner/stream_test.exs
@@ -23,11 +23,11 @@ defmodule K8s.Client.Runner.StreamTest do
       continue_token = "stream-failure-test"
 
       case params do
-        [limit: 10, continue: nil, labelSelector: ""] ->
+        [limit: 10, continue: nil, labelSelector: "", fieldSelector: ""] ->
           data = build_list(page1_items, continue_token)
           render(data, 200, [{"Content-Type", "application/json"}])
 
-        [limit: 10, continue: "stream-failure-test", labelSelector: ""] ->
+        [limit: 10, continue: "stream-failure-test", labelSelector: "", fieldSelector: ""] ->
           render(%{"reason" => "NotFound", "message" => "next page not found"}, 404, [
             {"Content-Type", "application/json"}
           ])
@@ -42,9 +42,14 @@ defmodule K8s.Client.Runner.StreamTest do
 
       body =
         case params do
-          [limit: 10, continue: nil, labelSelector: ""] -> build_list(page1_items, "start")
-          [limit: 10, continue: "start", labelSelector: ""] -> build_list(page2_items, "end")
-          [limit: 10, continue: "end", labelSelector: ""] -> build_list(page3_items)
+          [limit: 10, continue: nil, labelSelector: "", fieldSelector: ""] ->
+            build_list(page1_items, "start")
+
+          [limit: 10, continue: "start", labelSelector: "", fieldSelector: ""] ->
+            build_list(page2_items, "end")
+
+          [limit: 10, continue: "end", labelSelector: "", fieldSelector: ""] ->
+            build_list(page3_items)
         end
 
       render(body, 200)

--- a/test/k8s/client/runner/watch_integration_test.exs
+++ b/test/k8s/client/runner/watch_integration_test.exs
@@ -32,7 +32,7 @@ defmodule K8s.Client.Runner.WatchIntegrationTest do
   test "watches an operation", %{conn: conn, labels: labels, test_id: test_id} do
     selector = K8s.Selector.label(labels)
     operation = K8s.Client.list("v1", "Pod", namespace: "default")
-    operation = K8s.Operation.put_label_selector(operation, selector)
+    operation = K8s.Operation.put_selector(operation, selector)
 
     this = self()
     {:ok, _reference} = K8s.Client.Runner.Watch.run(conn, operation, "0", stream_to: this)
@@ -93,7 +93,7 @@ defmodule K8s.Client.Runner.WatchIntegrationTest do
     } do
       selector = K8s.Selector.label(labels)
       operation = K8s.Client.list("v1", "ConfigMap", namespace: "default")
-      operation = K8s.Operation.put_label_selector(operation, selector)
+      operation = K8s.Operation.put_selector(operation, selector)
       {:ok, event_stream} = K8s.Client.Runner.Watch.stream(conn, operation)
 
       Task.start(fn -> event_stream |> handle_stream.() |> Stream.run() end)
@@ -137,7 +137,7 @@ defmodule K8s.Client.Runner.WatchIntegrationTest do
     } do
       selector = K8s.Selector.label(labels)
       operation = K8s.Client.get("v1", "ConfigMap", namespace: "default", name: resource_name)
-      operation = K8s.Operation.put_label_selector(operation, selector)
+      operation = K8s.Operation.put_selector(operation, selector)
       {:ok, event_stream} = K8s.Client.Runner.Watch.stream(conn, operation)
 
       Task.start(fn -> event_stream |> handle_stream.() |> Stream.run() end)
@@ -181,7 +181,7 @@ defmodule K8s.Client.Runner.WatchIntegrationTest do
     } do
       selector = K8s.Selector.label(labels)
       operation = K8s.Client.list("v1", "ConfigMap", namespace: "default")
-      operation = K8s.Operation.put_label_selector(operation, selector)
+      operation = K8s.Operation.put_selector(operation, selector)
       {:ok, event_stream} = K8s.Client.Runner.Watch.stream(conn, operation)
 
       Task.start(fn -> event_stream |> handle_stream.() |> Stream.run() end)

--- a/test/k8s/selector_integration_test.exs
+++ b/test/k8s/selector_integration_test.exs
@@ -1,0 +1,172 @@
+defmodule K8s.SelectorIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias K8s.Selector, as: MUT
+  alias K8s.Test.IntegrationHelper
+
+  setup_all do
+    conn = IntegrationHelper.conn()
+
+    cm =
+      IntegrationHelper.build_configmap("selector-integration-test", %{"foo" => "bar"},
+        labels: %{
+          "env" => "test",
+          "app" => "nginx",
+          "tier" => "backend"
+        }
+      )
+
+    K8s.Client.run(conn, K8s.Client.apply(cm))
+
+    on_exit(fn ->
+      K8s.Client.run(conn, K8s.Client.delete(cm))
+    end)
+
+    [conn: conn]
+  end
+
+  describe "labels" do
+    test "Finds resource via label selectors", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label({"tier", "backend"})
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+
+      assert "selector-integration-test" == resource["metadata"]["name"]
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label({"tier", "frontend"})
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+    end
+
+    test "Finds resource via label_not selectors", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_not({"tier", "frontend"})
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+
+      assert "selector-integration-test" == resource["metadata"]["name"]
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_not({"tier", "backend"})
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+    end
+
+    test "Finds resource via label_does_not_exist expression", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_does_not_exist("tier")
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_does_not_exist("foo")
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+      assert "selector-integration-test" == resource["metadata"]["name"]
+    end
+
+    test "Finds resource via label_exists expression", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_exists("foo")
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_exists("tier")
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+      assert "selector-integration-test" == resource["metadata"]["name"]
+    end
+
+    test "Finds resource via label_in and label_not_in expression", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_not_in({"tier", ["fronten", "backend"]})
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label_in({"tier", ["fronten", "backend"]})
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+      assert "selector-integration-test" == resource["metadata"]["name"]
+    end
+  end
+
+  describe "fields" do
+    test "Finds resource via field selectors", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label({"tier", "backend"})
+        |> MUT.field({"metadata.namespace", "default"})
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+
+      assert "selector-integration-test" == resource["metadata"]["name"]
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label({"tier", "backend"})
+        |> MUT.field({"metadata.namespace", "bar"})
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+    end
+
+    test "Finds resource via field_not selectors", %{conn: conn} do
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label({"tier", "backend"})
+        |> MUT.field_not({"metadata.namespace", "bar"})
+
+      {:ok, %{"items" => [resource]}} = K8s.Client.run(conn, op)
+
+      assert "selector-integration-test" == resource["metadata"]["name"]
+
+      op =
+        K8s.Client.list("v1", "ConfigMap", namespace: "default")
+        |> MUT.label({"env", "test"})
+        |> MUT.label({"app", "nginx"})
+        |> MUT.label({"tier", "backend"})
+        |> MUT.field_not({"metadata.namespace", "default"})
+
+      {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
+    end
+  end
+end

--- a/test/k8s/selector_integration_test.exs
+++ b/test/k8s/selector_integration_test.exs
@@ -26,6 +26,7 @@ defmodule K8s.SelectorIntegrationTest do
   end
 
   describe "labels" do
+    @tag integration: true
     test "Finds resource via label selectors", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")
@@ -46,6 +47,7 @@ defmodule K8s.SelectorIntegrationTest do
       {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
     end
 
+    @tag integration: true
     test "Finds resource via label_not selectors", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")
@@ -66,6 +68,7 @@ defmodule K8s.SelectorIntegrationTest do
       {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
     end
 
+    @tag integration: true
     test "Finds resource via label_does_not_exist expression", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")
@@ -85,6 +88,7 @@ defmodule K8s.SelectorIntegrationTest do
       assert "selector-integration-test" == resource["metadata"]["name"]
     end
 
+    @tag integration: true
     test "Finds resource via label_exists expression", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")
@@ -104,6 +108,7 @@ defmodule K8s.SelectorIntegrationTest do
       assert "selector-integration-test" == resource["metadata"]["name"]
     end
 
+    @tag integration: true
     test "Finds resource via label_in and label_not_in expression", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")
@@ -125,6 +130,7 @@ defmodule K8s.SelectorIntegrationTest do
   end
 
   describe "fields" do
+    @tag integration: true
     test "Finds resource via field selectors", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")
@@ -147,6 +153,7 @@ defmodule K8s.SelectorIntegrationTest do
       {:ok, %{"items" => []}} = K8s.Client.run(conn, op)
     end
 
+    @tag integration: true
     test "Finds resource via field_not selectors", %{conn: conn} do
       op =
         K8s.Client.list("v1", "ConfigMap", namespace: "default")


### PR DESCRIPTION
Took a quick stab at #40. Adds a new `match_fields` to `K8s.Selector` to hold key, values related
to the field selectors. As field selectors only work with equality-based requirements I embedded the operator in the value part of the kv-pair

Changed `merge` to branch depending on type of selector (`:label`, `:field`). So

```elixir
iex(1)> {"component", "redis"} |> K8s.Selector.label() |> K8s.Selector.field({"metadata.namespace", "default"})
%K8s.Selector{
  match_expressions: [],
  match_fields: %{"metadata.namespace" => {"=", "default"}},
  match_labels: %{"component" => "redis"}
}
```

and with an operation:

```elixir

iex(2)> K8s.Client.list("v1", :pods) |> K8s.Selector.label({"component", "redis"}) |> K8s.Selector.field({"metadata.namespace", "default"})
%K8s.Operation{
  api_version: "v1",
  data: nil,
  method: :get,
  name: :pods,
  path_params: [],
  query_params: [
    fieldSelector: %K8s.Selector{
      match_expressions: [],
      match_fields: %{"metadata.namespace" => {"=", "default"}},
      match_labels: %{}
    },
    labelSelector: %K8s.Selector{
      match_expressions: [],
      match_fields: %{},
      match_labels: %{"component" => "redis"}
    }
  ],
  verb: :list
}
```

I'm a little bit unsure what you had in mind so I thought I'll start simple. Let me know what you think!
