### PR TITLE
Security hazard: Peer certificates are not actually being validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve namespace in get_to_list/1 #122, #123
 - Fix obsolete doc on wait operation #118
 - Dialyzer errors with K8s.Client functions #119
+- Enable peer certificate authentication #127.  Be aware, this will break configurations that have been using incorrect certificate(s) up to this point.
 
 ## [1.0.0] - 2021-07-19
 

--- a/lib/k8s/conn.ex
+++ b/lib/k8s/conn.ex
@@ -195,7 +195,7 @@ defmodule K8s.Conn do
           verify_options =
             case conn.insecure_skip_tls_verify do
               true -> [verify: :verify_none]
-              _ -> []
+              _ -> [verify: :verify_peer]
             end
 
           ca_options =

--- a/test/k8s/conn_test.exs
+++ b/test/k8s/conn_test.exs
@@ -146,7 +146,7 @@ defmodule K8s.ConnTest do
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, cacerts: [_cert]] = ssl_options
+      assert [cert: _, key: _, verify: :verify_peer, cacerts: [_cert]] = ssl_options
     end
 
     test "when skipping TLS verification" do


### PR DESCRIPTION
I noticed that the first `K8s.Conn.run` I did was emitting an Erlang TLS warning:

```
[warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
```

Furthermore, I could (for example) take a `K8s.Conn` structure pointing to one server, replace the `ca_cert` property with the cert from a different server, and it would still happily connect.  No peer validation was happening at all.

At first I misunderstood this error message, and I thought it was saying "you're asking for `verify_peer` but you're not giving a `cacerts` or `cacertfile` option".  (This was clearly false, we were providing `cacerts` just fine.)

But after doing a bunch of tracing and discussing this issue on the Elixir Slack, I learned that the root of the issue is that peer validation is disabled in Erlang by default.  You can ask for `verify_peer` which will enable it, or you can ask for `verify_none` which will *explicitly* disable it — but if you don't ask for either, you basically get the `verify_none` behaviour but with the above warning.

(Of course, HTTPoison does peer validation by default, using the certs from `certifi`.  But if you specify any `ssl` options at all, you completely override HTTPoison's own TLS parameters, exposing you to this issue.)

This was a one-line fix once I knew the issue, and with this change, I can verify that I can no longer swap certificates or MitM my K8s connections.