### PR TITLE
Setup nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,7 @@
 direnv_version 2.30.3
 # IEx Persistent History, see https://tylerpachal.medium.com/iex-persistent-history-5d7d64e905d3
 export ERL_AFLAGS="-kernel shell_history enabled"
+if has nix && nix show-config 2> /dev/null | grep "experimental-features" | grep -q "flakes"
+then
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ k8s-*.tar
 
 # Ignore local k8s config/integration test files
 integration.yaml
+
+# direnv & nix
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Kubernetes API Client for Elixir";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShell = pkgs.mkShell {
+          packages = [
+            pkgs.elixir
+          ];
+        };
+      });
+}


### PR DESCRIPTION
* use latest version of elixir as provided by nix (currently locked to 1.13.3 / OTP 24)
* as an alternative to asdf based devenv
* with direnv integration