### PR TITLE
Add support for FQDN K8s API servers and Root CA chains

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,4 @@ config :k8s,
   discovery_driver: K8s.Discovery.Driver.File,
   discovery_opts: [config: "test/support/discovery/example.json"],
   http_provider: K8s.Client.DynamicHTTPProvider,
-  ca_provider: CAStore
+  cacertfile: "/etc/ssl/cert.pem"

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,4 +3,5 @@ import Config
 config :k8s,
   discovery_driver: K8s.Discovery.Driver.File,
   discovery_opts: [config: "test/support/discovery/example.json"],
-  http_provider: K8s.Client.DynamicHTTPProvider
+  http_provider: K8s.Client.DynamicHTTPProvider,
+  ca_provider: CAStore

--- a/lib/k8s.ex
+++ b/lib/k8s.ex
@@ -44,4 +44,12 @@ defmodule K8s do
   def default_discovery_opts do
     Application.get_env(:k8s, :discovery_opts, [])
   end
+
+  @doc """
+  Returns the default CAStore
+  """
+  @spec default_ca_provider() :: module()
+  def default_ca_provider do
+    Application.get_env(:k8s, :ca_provider, CAStore)
+  end
 end

--- a/lib/k8s.ex
+++ b/lib/k8s.ex
@@ -48,8 +48,8 @@ defmodule K8s do
   @doc """
   Returns the default CAStore
   """
-  @spec default_ca_provider() :: module()
-  def default_ca_provider do
-    Application.get_env(:k8s, :ca_provider, CAStore)
+  @spec default_cacertfile() :: module()
+  def default_cacertfile do
+    Application.get_env(:k8s, :cacertfile, CAStore.file_path())
   end
 end

--- a/lib/k8s/conn.ex
+++ b/lib/k8s/conn.ex
@@ -28,7 +28,8 @@ defmodule K8s.Conn do
             middleware: K8s.Middleware.Stack.default(),
             discovery_driver: K8s.default_discovery_driver(),
             discovery_opts: K8s.default_discovery_opts(),
-            http_provider: K8s.default_http_provider()
+            http_provider: K8s.default_http_provider(),
+            ca_provider: K8s.default_ca_provider()
 
   @typedoc """
   * `cluster_name` - The cluster name if read from a kubeconfig file
@@ -45,7 +46,8 @@ defmodule K8s.Conn do
           middleware: K8s.Middleware.Stack.t(),
           discovery_driver: module(),
           discovery_opts: Keyword.t(),
-          http_provider: module()
+          http_provider: module(),
+          ca_provider: module(),
         }
 
   @doc """
@@ -204,7 +206,7 @@ defmodule K8s.Conn do
 
           ca_options =
             case conn.ca_cert do
-              nil -> []
+              nil -> [cacertfile: conn.ca_provider.file_path() |> String.to_charlist()]
               cert -> [cacerts: [cert]]
             end
 

--- a/lib/k8s/conn.ex
+++ b/lib/k8s/conn.ex
@@ -29,7 +29,7 @@ defmodule K8s.Conn do
             discovery_driver: K8s.default_discovery_driver(),
             discovery_opts: K8s.default_discovery_opts(),
             http_provider: K8s.default_http_provider(),
-            ca_provider: K8s.default_ca_provider()
+            cacertfile: K8s.default_cacertfile()
 
   @typedoc """
   * `cluster_name` - The cluster name if read from a kubeconfig file
@@ -47,7 +47,7 @@ defmodule K8s.Conn do
           discovery_driver: module(),
           discovery_opts: Keyword.t(),
           http_provider: module(),
-          ca_provider: module(),
+          cacertfile: String.t(),
         }
 
   @doc """
@@ -206,7 +206,7 @@ defmodule K8s.Conn do
 
           ca_options =
             case conn.ca_cert do
-              nil -> [cacertfile: conn.ca_provider.file_path() |> String.to_charlist()]
+              nil -> [cacertfile: conn.cacertfile |> String.to_charlist()]
               cert -> [cacerts: [cert]]
             end
 

--- a/lib/k8s/conn.ex
+++ b/lib/k8s/conn.ex
@@ -47,7 +47,7 @@ defmodule K8s.Conn do
           discovery_driver: module(),
           discovery_opts: Keyword.t(),
           http_provider: module(),
-          cacertfile: String.t(),
+          cacertfile: String.t()
         }
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule K8s.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:castore, ">= 0.0.0"},
+      {:castore, "~> 0.1"},
       {:yaml_elixir, "~> 2.8"},
       {:httpoison, "~> 1.7"},
       {:jason, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule K8s.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:castore, ">= 0.0.0"},
       {:yaml_elixir, "~> 2.8"},
       {:httpoison, "~> 1.7"},
       {:jason, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "credo": {:hex, :credo, "1.6.4", "ddd474afb6e8c240313f3a7b0d025cc3213f0d171879429bf8535d7021d9ad78", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "c28f910b61e1ff829bffa056ef7293a8db50e87f2c57a9b5c3f57eee124536b7"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},

--- a/test/k8s/conn_test.exs
+++ b/test/k8s/conn_test.exs
@@ -118,24 +118,25 @@ defmodule K8s.ConnTest do
   describe "generating RequestOptions" do
     test "generates headers for the given auth provider" do
       opts = [user: "token-user", cluster: "insecure-cluster"]
+      cacertfile = '#{File.cwd!()}/_build/test/lib/castore/priv/cacerts.pem'
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
-
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
       assert [Authorization: _bearer_token] = headers
-      assert [verify: :verify_none] = ssl_options
+      assert [verify: :verify_none, cacertfile: ^cacertfile] = ssl_options
     end
 
     test "generates ssl_options for the given auth provider" do
       opts = [user: "pem-cert-user", cluster: "insecure-cluster"]
+      cacertfile = '#{File.cwd!()}/_build/test/lib/castore/priv/cacerts.pem'
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
 
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, verify: :verify_none] = ssl_options
+      assert [cert: _, key: _, verify: :verify_none, cacertfile: ^cacertfile] = ssl_options
     end
 
     test "includes cacerts if provided" do
@@ -151,13 +152,14 @@ defmodule K8s.ConnTest do
 
     test "when skipping TLS verification" do
       opts = [user: "pem-cert-user", cluster: "insecure-cluster"]
+      cacertfile = '#{File.cwd!()}/_build/test/lib/castore/priv/cacerts.pem'
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
 
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, verify: :verify_none] = ssl_options
+      assert [cert: _, key: _, verify: :verify_none, cacertfile: ^cacertfile] = ssl_options
     end
   end
 end

--- a/test/k8s/conn_test.exs
+++ b/test/k8s/conn_test.exs
@@ -119,6 +119,7 @@ defmodule K8s.ConnTest do
     test "generates headers for the given auth provider" do
       opts = [user: "token-user", cluster: "insecure-cluster"]
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
+
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
@@ -134,7 +135,9 @@ defmodule K8s.ConnTest do
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] = ssl_options
+
+      assert [cert: _, key: _, verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] =
+               ssl_options
     end
 
     test "includes cacerts if provided" do
@@ -156,7 +159,9 @@ defmodule K8s.ConnTest do
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] = ssl_options
+
+      assert [cert: _, key: _, verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] =
+               ssl_options
     end
   end
 end

--- a/test/k8s/conn_test.exs
+++ b/test/k8s/conn_test.exs
@@ -118,25 +118,23 @@ defmodule K8s.ConnTest do
   describe "generating RequestOptions" do
     test "generates headers for the given auth provider" do
       opts = [user: "token-user", cluster: "insecure-cluster"]
-      cacertfile = '#{File.cwd!()}/_build/test/lib/castore/priv/cacerts.pem'
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
       assert [Authorization: _bearer_token] = headers
-      assert [verify: :verify_none, cacertfile: ^cacertfile] = ssl_options
+      assert [verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] = ssl_options
     end
 
     test "generates ssl_options for the given auth provider" do
       opts = [user: "pem-cert-user", cluster: "insecure-cluster"]
-      cacertfile = '#{File.cwd!()}/_build/test/lib/castore/priv/cacerts.pem'
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
 
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, verify: :verify_none, cacertfile: ^cacertfile] = ssl_options
+      assert [cert: _, key: _, verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] = ssl_options
     end
 
     test "includes cacerts if provided" do
@@ -152,14 +150,13 @@ defmodule K8s.ConnTest do
 
     test "when skipping TLS verification" do
       opts = [user: "pem-cert-user", cluster: "insecure-cluster"]
-      cacertfile = '#{File.cwd!()}/_build/test/lib/castore/priv/cacerts.pem'
       {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml", opts)
 
       assert {:ok, %RequestOptions{headers: headers, ssl_options: ssl_options}} =
                RequestOptions.generate(conn)
 
       assert headers == []
-      assert [cert: _, key: _, verify: :verify_none, cacertfile: ^cacertfile] = ssl_options
+      assert [cert: _, key: _, verify: :verify_none, cacertfile: '/etc/ssl/cert.pem'] = ssl_options
     end
   end
 end


### PR DESCRIPTION
# Problem
Our k8s API servers use a fully qualified domain name and TLS certs from LetsEncrypt. In the current implementation no root CA certfiles are provided to HTTPoison. This causes an error when trying to configure and use a connection like below with `:verify_peer`. This is a bit unexpected. 

```elixir
> {:ok, auth} = K8s.Conn.Auth.Token.create(%{"token" => "avalidbearertokenhere"})
...
> conn = %K8s.Conn{auth: auth, cluster_name: "thephw", ca_cert: nil, user_name: "thephw", url: "https://k8s.flowerwork.net/"}
...
> operation = K8s.Client.list("v1", "Node") 
...
> conn  |> K8s.Client.run(operation)
{:error, %HTTPoison.Error{id: nil, reason: {:options, {:cacertfile, []}}}}
```

# Prior Art
Looked at a handful of other elixir libraries to see how they were managing root CA files. Most of them were using [CAStore](https://github.com/elixir-mint/castore)

- [tailwind hex package usage](https://github.com/phoenixframework/tailwind/blob/master/lib/tailwind.ex#L289)
- [esbuild hex package usage](https://github.com/phoenixframework/esbuild/blob/main/lib/esbuild.ex#L303)

# Solution
Add CAStore dependency and integrate `cacertfile` option into K8s.Conn with `CAStore.file_path()` as the default.

# Changelog
* Add [CAStore](https://github.com/elixir-mint/castore) dependency for root CAs
* This adds support for k8s servers using TLS certs with a custody chain back to a root certificate authority. i.e. no intermediate certificates
* This would be typical of any k8s server with a public API available at a FQDN with a TLS cert whose chain of custody is covered by the root certificate authorities.
* Sets the default ca_provider on K8s.Conn to CAStore
* Sets the default cacertfile parameter for ssl_options to `conn. cacertfile`
* Update `conn_test.exs` assertions for ssl_options
* This makes the default when not using an intermediate certificate chain to use the root CA certificate chain.
* This does not change the behavior when using connection configuration with intermediate certificate authorities
