### PR TITLE
Turn get to list before retrieving resource version - refs #145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Fix 410 Gone not rescued in `watch_and_stream/2`
-- Request BOOKMARK events and process them when watching resource collections.
+### Fixed
+
+- `K8s.Client.watch_and_stream/2`: 410 Gone not rescued [#159](https://github.com/coryodaniel/k8s/pull/159)
+- `K8s.Client.watch/3`: `get` operations should be transformed to `list` BEFORE retrieving the resource version [#160](https://github.com/coryodaniel/k8s/pull/160)
+
+### Added
+
+- `K8s.Client.watch_and_stream/2`: Request BOOKMARK events and process them when watching resource collections. [#159](https://github.com/coryodaniel/k8s/pull/159)
 
 ## [1.1.4] - 2022-03-15
 

--- a/test/k8s/client/runner/watch_test.exs
+++ b/test/k8s/client/runner/watch_test.exs
@@ -25,7 +25,10 @@ defmodule K8s.Client.Runner.WatchTest do
     end
 
     def request(:get, @namespaced_url <> "/test", _, _, _) do
-      render(nil)
+      raise """
+      The resource version should be retrieved from the resource collection, NOT the resource!
+      I.e. the library should call list, not get to retrieve it.
+      """
     end
   end
 


### PR DESCRIPTION
Fixes the "too old resource version" error in `K8s.Client.watch/3` in case of watching GET operations. The problem was that the resource version was retrieved from the resource instead of the resource collection