### PR TITLE
Update K8s.Conn.from_file to support fully qualified domain names (FQDN)

### DIFF
--- a/lib/k8s/conn/pki.ex
+++ b/lib/k8s/conn/pki.ex
@@ -30,7 +30,7 @@ defmodule K8s.Conn.PKI do
     |> PKI.cert_from_pem()
   end
 
-  def cert_from_map(%{"insecure-skip-tls-verify" => true}, _), do: {:ok, nil}
+  def cert_from_map(_, _), do: {:ok, nil}
 
   @doc """
   Reads the certificate from a PEM file


### PR DESCRIPTION
### Changelog
- Update `PKI.cert_from_map/2` to support fully qualified domain names (FQDN)
- I missed a codepath in the original PR that makes this not work with a
  call from `K8s.Conn.from_file/1` when using a FQDN for the server url.
- Ref: https://github.com/coryodaniel/k8s/pull/144
