### PR TITLE
use discovery_opts from conn in file discovery driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `K8s.Resourse.label/2`: spec updated to accept label maps as a second argument [#177](https://github.com/coryodaniel/k8s/pull/177)
-
-
-
-
-
-
-
-
+- `K8s.Discovery.Driver.File`: Use `conn.discovery_opts` in file discovery driver([#180](https://github.com/coryodaniel/k8s/pull/180))
 
 <!--------------------- Don't add new entries after this line --------------------->
 

--- a/lib/k8s/discovery/driver/file.ex
+++ b/lib/k8s/discovery/driver/file.ex
@@ -34,10 +34,12 @@ defmodule K8s.Discovery.Driver.File do
   @behaviour K8s.Discovery.Driver
 
   @impl true
-  def resources(api_version, %K8s.Conn{}, opts \\ []), do: get_resources(api_version, opts)
+  def resources(api_version, %K8s.Conn{} = conn, opts \\ []),
+    do: get_resources(api_version, Keyword.merge(conn.discovery_opts, opts))
 
   @impl true
-  def versions(%K8s.Conn{}, opts \\ []), do: get_versions(opts)
+  def versions(%K8s.Conn{} = conn, opts \\ []),
+    do: get_versions(Keyword.merge(conn.discovery_opts, opts))
 
   @spec get_versions(keyword) :: {:ok, list(binary)} | {:error, :enoent | Jason.DecodeError.t()}
   defp get_versions(opts) do


### PR DESCRIPTION
Discovery drivers should use the field `discovery_opts` from the `conn` object. This was not implemented on the file discovery driver

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created