### PR TITLE
Match subresources when the kind does not equal the subresource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix protocol implementations in Elixir 1.14.1: Replace `__MODULE__` with actual module name. [#185](https://github.com/coryodaniel/k8s/pull/185)
+- Match subresources when the kind does not equal the subresource ([#184](https://github.com/coryodaniel/bonny/issues/184))
 
 <!--------------------- Don't add new entries after this line --------------------->
 

--- a/lib/k8s/discovery/resource_finder.ex
+++ b/lib/k8s/discovery/resource_finder.ex
@@ -49,7 +49,9 @@ defmodule K8s.Discovery.ResourceFinder do
     case resource do
       nil ->
         {:error,
-         %K8s.Discovery.Error{message: "Unsupported Kubernetes resource: #{name_or_kind}"}}
+         %K8s.Discovery.Error{
+           message: "Unsupported Kubernetes resource: #{inspect(name_or_kind)}"
+         }}
 
       resource ->
         {:ok, resource}

--- a/lib/k8s/discovery/resource_naming.ex
+++ b/lib/k8s/discovery/resource_naming.ex
@@ -21,6 +21,10 @@ defmodule K8s.Discovery.ResourceNaming do
       iex> K8s.Discovery.ResourceNaming.matches?(%{"kind" => "Eviction", "name" => "pods/eviction"}, {"Pod", "Eviction"})
       true
 
+      Supports matching tuples of `{resource, subresource}` kind
+      iex> K8s.Discovery.ResourceNaming.matches?(%{"kind" => "Deployment", "name" => "deployments/status"}, {"Deployment", "Status"})
+      true
+
       Supports matching subresources
       iex> K8s.Discovery.ResourceNaming.matches?(%{"kind" => "Deployment", "name" => "deployments/status"}, "deployments/status")
       true
@@ -58,6 +62,11 @@ defmodule K8s.Discovery.ResourceNaming do
   def matches?(%{"kind" => subkind, "name" => name} = _subresource, {kind, subkind}) do
     resource_kind_as_nameish = String.downcase(kind)
     String.starts_with?(name, resource_kind_as_nameish)
+  end
+
+  def matches?(%{"kind" => kind, "name" => name} = _subresource, {kind, subkind}) do
+    subkind_as_nameish = String.downcase(subkind)
+    String.ends_with?(name, "/" <> subkind_as_nameish)
   end
 
   def matches?(_map, {_kind, _subkind}), do: false


### PR DESCRIPTION
The following case did not match but should 

```elixir
K8s.Discovery.ResourceNaming.matches?(%{"kind" => "Deployment", "name" => "deployments/status"}, {"Deployment", "Status"})
```
---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [ ] Entry in CHANGELOG.md was created
