### PR TITLE
Get resource version first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Fixed
+
+`K8s.Client.watch_and_stream/2`: Get resource vesrion before creating the Stream resource in order to not miss anything. ([#187](https://github.com/coryodaniel/k8s/pull/187))
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [1.1.7] - 2022-10-15

--- a/lib/k8s/client/runner/async.ex
+++ b/lib/k8s/client/runner/async.ex
@@ -30,8 +30,7 @@ defmodule K8s.Client.Runner.Async do
     results = K8s.Client.Runner.Async.run(conn, operations)
     ```
   """
-  @spec run(Conn.t(), list(Operation.t()), keyword) ::
-          list({:ok, struct} | {:error, Base.error_t()})
+  @spec run(Conn.t(), list(Operation.t()), keyword) :: list(Base.result_t())
   def run(%Conn{} = conn, operations, http_opts \\ []) do
     operations
     |> Enum.map(&Task.async(fn -> Base.run(conn, &1, http_opts) end))

--- a/lib/k8s/client/runner/watch/stream.ex
+++ b/lib/k8s/client/runner/watch/stream.ex
@@ -32,8 +32,18 @@ defmodule K8s.Client.Runner.Watch.Stream do
   """
   @spec resource(K8s.Conn.t(), K8s.Operation.t(), keyword()) :: Enumerable.t() | {:error, any()}
   def resource(conn, operation, http_opts) do
+    {:ok, resource_version} = Watch.get_resource_version(conn, operation)
+
     Stream.resource(
-      fn -> {:start, %__MODULE__{conn: conn, operation: operation, http_opts: http_opts}} end,
+      fn ->
+        {:start,
+         %__MODULE__{
+           conn: conn,
+           operation: operation,
+           http_opts: http_opts,
+           resource_version: resource_version
+         }}
+      end,
       &next_fun/1,
       fn _state -> :ok end
     )


### PR DESCRIPTION
`K8s.Client.watch_and_stream/2` first has to query the resource version of the resource list to watch. This was done first thing inside the Stream resource. However, in order to start the watch as early as possible and not miss any events, the resource version has to be queried first and passed to the initial state of the Stream resource.

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created