### PR TITLE
fix: `K8s.Client.run/2` spec missing a possible error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Fixed
+`K8s.Client.run/2`: spec updated to include `t:K8s.Client.APIError.t/0` in possible error structs
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [1.1.8] - 2022-10-26

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -6,6 +6,7 @@ defmodule K8s.Client.Runner.Base do
   @type error_t ::
           {:error, K8s.Middleware.Error.t()}
           | {:error, K8s.Operation.Error.t()}
+          | {:error, K8s.Client.APIError.t()}
           | {:error, atom()}
           | {:error, binary()}
   @type result_t :: {:ok, map() | reference()} | error_t


### PR DESCRIPTION
<!-- Describe your pull request here. !-->

 `K8s.Client.run/2` (actually `t:K8s.Client.Runner.Base.error_t/0`) spec was missing `t:K8s.Client.APIError.t/0` from possible error types, making code like this trigger Dialyzer warnings:

```elixir
case K8s.Client.run(conn, operation) do
  {:ok, result} -> {:ok, result}
  {:error, %K8s.Client.APIError{} = error} -> # ... This case is marked as "can never match the type"
end
```

I'm aware that this type may actually be missing from the return union based on the chosen HTTP provider (this error is from `K8s.Client.HTTPProvider.handle_kubernetes_error/1`), but it is present when you're using the defaults and it would be nice to have that reflected without suppressing Dialyzer warnings at the point of use.

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created
