### PR TITLE
Ws message lines as a Stream

### DIFF
--- a/lib/k8s/client/dynamic_websocket_provider.ex
+++ b/lib/k8s/client/dynamic_websocket_provider.ex
@@ -26,6 +26,10 @@ defmodule K8s.Client.DynamicWebSocketProvider do
     GenServer.call(__MODULE__, {:request, opts})
   end
 
+  def stop(_pid, _reason \\ :normal) do
+    :ok
+  end
+
   @spec init(atom) :: {:ok, map()}
   def init(:ok) do
     {:ok, %{}}

--- a/lib/k8s/client/dynamic_websocket_provider.ex
+++ b/lib/k8s/client/dynamic_websocket_provider.ex
@@ -26,6 +26,7 @@ defmodule K8s.Client.DynamicWebSocketProvider do
     GenServer.call(__MODULE__, {:request, opts})
   end
 
+  @spec stop(pid(), term()) :: :ok
   def stop(_pid, _reason \\ :normal) do
     :ok
   end

--- a/lib/k8s/client/runner/stream.ex
+++ b/lib/k8s/client/runner/stream.ex
@@ -4,7 +4,7 @@ defmodule K8s.Client.Runner.Stream do
   """
 
   alias K8s.Client.Runner.Base
-  alias K8s.Client.Runner.Stream.{ListRequest, ConnectRequest}
+  alias K8s.Client.Runner.Stream.{ConnectRequest, ListRequest}
   alias K8s.Conn
   alias K8s.Operation
   alias K8s.Operation.Error

--- a/lib/k8s/client/runner/stream/connect_request.ex
+++ b/lib/k8s/client/runner/stream/connect_request.ex
@@ -1,0 +1,122 @@
+defmodule K8s.Client.Runner.Stream.ConnectRequest do
+  @moduledoc "`:connect` `K8s.Operation` encapsulated with pagination and `K8s.Conn`"
+
+  @type t :: %__MODULE__{
+          operation: K8s.Operation.t(),
+          conn: K8s.Conn.t(),
+          continue: :halt | :cont,
+          http_opts: keyword(),
+          recv_ref: reference(),
+          monitor_pid: pid(),
+          monitor_ref: reference()
+        }
+  alias K8s.Client.Runner.Base
+
+  defstruct [
+    :operation,
+    :conn,
+    :recv_ref,
+    :monitor_pid,
+    :monitor_ref,
+    continue: :cont,
+    http_opts: []
+  ]
+
+  @doc """
+  Creates a `ConnectRequest` and spawns a process that will own and consume
+  the ws connection.
+  """
+  def init(conn, op, http_opts \\ []) do
+    parent = self()
+    recv_ref = make_ref()
+
+    {monitor_pid, monitor_ref} =
+      spawn_monitor(fn -> init_stream(parent, recv_ref, conn, op, http_opts) end)
+
+    %__MODULE__{
+      conn: conn,
+      operation: op,
+      http_opts: http_opts,
+      monitor_pid: monitor_pid,
+      monitor_ref: monitor_ref,
+      recv_ref: recv_ref
+    }
+  end
+
+  @doc """
+  Receive the next message from the connection:
+
+  * If the ws conneciton exits with normal emit `{:exit, :normal}`
+  * Any reason such as errors are passed as is `{:error, term()}`
+  * Messages from the ws connection are sent to the parent as a `{:message, ref, msg}`
+  """
+  def next(%__MODULE__{continue: :halt} = t) do
+    {:halt, t}
+  end
+
+  def next(%__MODULE__{continue: :cont, monitor_ref: ref, recv_ref: recv_ref} = t) do
+    receive do
+      {:DOWN, ^ref, _, _, reason} ->
+        # emit exit reason, set next state to be halted
+        msg =
+          if is_atom(reason) do
+            {:exit, reason}
+          else
+            reason
+          end
+
+        {[msg], %{t | continue: :halt}}
+
+      {:message, ^recv_ref, msg} ->
+        lines = String.split(msg, "\r\n")
+        {lines, t}
+    end
+  end
+
+  @doc """
+  Close the monitor and ws connection.
+  """
+  def close_stream(%__MODULE__{monitor_pid: pid, monitor_ref: m_ref, recv_ref: ref}) do
+    send(pid, {:stop, ref})
+
+    Process.demonitor(m_ref, [:flush])
+  end
+
+  defp init_stream(parent, recv_ref, conn, op, opts) do
+    run = opts[:run] || (&Base.run/3)
+    opts = Keyword.put(opts, :stream_to, self())
+    parent_ref = Process.monitor(parent)
+
+    case run.(conn, op, opts) do
+      {:ok, pid} ->
+        stream_ref = Process.monitor(pid)
+        recv({parent, parent_ref}, recv_ref, {pid, stream_ref})
+
+      {:error, reason} ->
+        exit(reason)
+    end
+  end
+
+  defp recv({parent, parent_ref} = p, recv_ref, {stream_pid, stream_ref} = s) do
+    receive do
+      {:ok, msg} ->
+        send(parent, {:message, recv_ref, msg})
+        recv(p, recv_ref, s)
+
+      {:stop, ^stream_ref} ->
+        K8s.websocket_provider().stop(stream_pid)
+
+      {:DOWN, ^parent_ref, _, _, reason} ->
+        K8s.websocket_provider().stop(stream_pid)
+        exit(reason)
+
+      {:DOWN, ^stream_ref, _, _, reason} ->
+        exit(reason)
+
+      _other ->
+        # {:exit, {:remote, _, _}}
+        # Send these messages to parent?
+        recv(p, recv_ref, s)
+    end
+  end
+end

--- a/lib/k8s/client/websocket_provider.ex
+++ b/lib/k8s/client/websocket_provider.ex
@@ -47,6 +47,10 @@ defmodule K8s.Client.WebSocketProvider do
     WebSockex.start_link(conn, __MODULE__, state, async: true)
   end
 
+  def stop(pid, reason \\ :normal) do
+    GenServer.stop(pid, reason)
+  end
+
   @spec handle_connect(conn :: WebSockex.Conn.t(), state :: term) :: {:ok, term}
   def handle_connect(_conn, %{monitor_ref: nil, stream_to: stream_to} = state) do
     ref = Process.monitor(stream_to)

--- a/lib/k8s/client/websocket_provider.ex
+++ b/lib/k8s/client/websocket_provider.ex
@@ -47,6 +47,7 @@ defmodule K8s.Client.WebSocketProvider do
     WebSockex.start_link(conn, __MODULE__, state, async: true)
   end
 
+  @spec stop(pid(), term()) :: :ok
   def stop(pid, reason \\ :normal) do
     GenServer.stop(pid, reason)
   end

--- a/test/k8s/client/runner/stream_integration_test.exs
+++ b/test/k8s/client/runner/stream_integration_test.exs
@@ -41,4 +41,22 @@ defmodule K8s.Client.Runner.StreamIntegrationTest do
 
     assert resources == ["stream-nginx-#{test_id}-1", "stream-nginx-#{test_id}-2"]
   end
+
+  @tag integration: true
+  test "running a command in a container", %{conn: conn} do
+    connect_op =
+      K8s.Client.connect("v1", "pods/exec", namespace: "default", name: "nginx-76d6c9b8c-sq56w")
+
+    operation =
+      K8s.Operation.put_query_param(connect_op,
+        command: ["/bin/sh", "-c", "date"],
+        stdin: true,
+        stdout: true,
+        stderr: true,
+        tty: true
+      )
+
+    assert {:ok, stream} = K8s.Client.Runner.Stream.run(conn, operation)
+    assert Enum.take(stream, 1) != []
+  end
 end

--- a/test/k8s/client/runner/stream_test.exs
+++ b/test/k8s/client/runner/stream_test.exs
@@ -86,7 +86,6 @@ defmodule K8s.Client.Runner.StreamTest do
         msg =
           "total 2\r\ndrwxr-xr-x   2 root root 4096 Nov 14 00:00 bin\r\ndrwxr-xr-x   2 root root 4096 Sep  3 12:10 boot\r\n"
 
-        IO.inspect(opts[:stream_to])
         Process.send_after(opts[:stream_to], {:ok, msg}, 1)
         {:ok, self()}
       end


### PR DESCRIPTION
As discussed in #190 this implements the ability to consume ws messages as a Stream. It does so by utilising `Stream.resource/3` with a monitor process in between the caller and the connection.
---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [ ] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [x] New unit tests were created
- [x] New integration tests were created
- [ ] PR description contains a link to the according kubernetes documentation
