### PR TITLE
Add Operation.put_conn/2 to enable pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `K8s.Client.MintHTTPProvider` - The mint client implementation
 - `K8s.Client.HTTPTestHelper` - to be used in tests (resides in `lib/` so it can be used by dependents)
 - Open `:connect` operations (connections) now accept messages to be sent to pods
+- `K8s.Client.put_conn/2` to add pielining support to the Client API
 
 ### Changed
 

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -19,8 +19,11 @@
 opts = [namespace: "default", name: "nginx", image: "nginx:nginx:1.7.9"]
 {:ok, resource} = K8s.Resource.from_file("priv/deployment.yaml", opts)
 
-operation = K8s.Client.create(resource)
-{:ok, deployment} = K8s.Client.run(conn, operation)
+{:ok, deployment} =
+    resource
+    |> K8s.Client.create()
+    |> K8s.Client.put_conn(conn)
+    |> K8s.Client.run()
 ```
 
 ### Listing deployments
@@ -30,8 +33,10 @@ In a namespace:
 ```elixir
 {:ok, conn} = K8s.Conn.from_file("path/to/kubeconfig.yaml")
 
-operation = K8s.Client.list("apps/v1", "Deployment", namespace: "prod")
-{:ok, deployments} = K8s.Client.run(conn, operation)
+{:ok, deployments} =
+    K8s.Client.list("apps/v1", "Deployment", namespace: "prod")
+    |> K8s.Client.put_conn(conn)
+    |> K8s.Client.run()
 ```
 
 Across all namespaces:
@@ -39,8 +44,10 @@ Across all namespaces:
 ```elixir
 {:ok, conn} = K8s.Conn.from_file("path/to/kubeconfig.yaml")
 
-operation = K8s.Client.list("apps/v1", "Deployment", namespace: :all)
-{:ok, deployments} = K8s.Client.run(conn, operation)
+{:ok, deployments} =
+    K8s.Client.list("apps/v1", "Deployment", namespace: :all)
+    |> K8s.Client.put_conn(conn)
+    |> K8s.Client.run()
 ```
 
 ### Getting a deployment
@@ -48,6 +55,8 @@ operation = K8s.Client.list("apps/v1", "Deployment", namespace: :all)
 ```elixir
 {:ok, conn} = K8s.Conn.from_file("path/to/kubeconfig.yaml")
 
-operation = K8s.Client.get("apps/v1", :deployment, [namespace: "default", name: "nginx-deployment"])
-{:ok, deployment} = K8s.Client.run(conn, operation)
+{:ok, deployment} =
+    K8s.Client.get("apps/v1", :deployment, [namespace: "default", name: "nginx-deployment"])
+    |> K8s.Client.put_conn(conn)
+    |> K8s.Client.run(conn, operation)
 ```

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -27,17 +27,13 @@ defmodule K8s.Client do
     force: true
   }
 
-  alias K8s.Conn
   alias K8s.Operation
   alias K8s.Client.Runner.{Async, Base, Stream, Wait}
 
   defdelegate put_conn(operation, conn), to: Operation
 
-  @spec run(Operation.t(), keyword()) :: K8s.Client.Provider.response_t()
-  def run(operation, http_opts \\ [])
-
-  def run(%Operation{conn: %Conn{} = conn} = operation, http_opts),
-    do: Base.run(conn, operation, http_opts)
+  @doc "alias of `K8s.Client.Runner.Base.run/1`"
+  defdelegate run(operation), to: Base
 
   @doc "alias of `K8s.Client.Runner.Base.run/2`"
   defdelegate run(conn, operation), to: Base
@@ -54,18 +50,13 @@ defmodule K8s.Client do
   @doc "alias of `K8s.Client.Runner.Async.run/3`"
   defdelegate parallel(conn, operations, http_opts), to: Async, as: :run
 
-  @spec wait_until(Operation.t(), keyword()) :: K8s.Client.Provider.response_t()
-  def wait_until(%Operation{conn: %Conn{} = conn} = operation, wait_opts \\ []),
-    do: Wait.run(conn, operation, wait_opts)
+  @doc "alias of `K8s.Client.Runner.Wait.run/2`"
+  defdelegate wait_until(operation, wait_opts), to: Wait, as: :run
 
   @doc "alias of `K8s.Client.Runner.Wait.run/3`"
   defdelegate wait_until(conn, operation, wait_opts), to: Wait, as: :run
 
-  @spec stream(Operation.t(), keyword()) :: K8s.Client.Provider.stream_response_t()
-  def stream(operation, wait_opts \\ [])
-
-  def stream(%Operation{conn: %Conn{} = conn} = operation, wait_opts),
-    do: Stream.run(conn, operation, wait_opts)
+  defdelegate stream(operation), to: Stream, as: :run
 
   @doc "alias of `K8s.Client.Runner.Stream.run/2`"
   defdelegate stream(conn, operation), to: Stream, as: :run

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -27,16 +27,25 @@ defmodule K8s.Client do
     force: true
   }
 
+  alias K8s.Conn
   alias K8s.Operation
   alias K8s.Client.Runner.{Async, Base, Stream, Wait}
+
+  defdelegate put_conn(operation, conn), to: Operation
+
+  @spec run(Operation.t(), keyword()) :: K8s.Client.Provider.response_t()
+  def run(operation, http_opts \\ [])
+
+  def run(%Operation{conn: %Conn{} = conn} = operation, http_opts),
+    do: Base.run(conn, operation, http_opts)
 
   @doc "alias of `K8s.Client.Runner.Base.run/2`"
   defdelegate run(conn, operation), to: Base
 
   @doc "alias of `K8s.Client.Runner.Base.run/3`"
   defdelegate run(conn, operation, http_opts), to: Base
-
   @doc "alias of `K8s.Client.Runner.Async.run/3`"
+
   defdelegate async(conn, operations), to: Async, as: :run
 
   @doc "alias of `K8s.Client.Runner.Async.run/3`"
@@ -45,17 +54,22 @@ defmodule K8s.Client do
   @doc "alias of `K8s.Client.Runner.Async.run/3`"
   defdelegate parallel(conn, operations, http_opts), to: Async, as: :run
 
+  @spec wait_until(Operation.t(), keyword()) :: K8s.Client.Provider.response_t()
+  def wait_until(%Operation{conn: %Conn{} = conn} = operation, wait_opts \\ []),
+    do: Wait.run(conn, operation, wait_opts)
+
   @doc "alias of `K8s.Client.Runner.Wait.run/3`"
   defdelegate wait_until(conn, operation, wait_opts), to: Wait, as: :run
+
+  @spec stream(Operation.t(), keyword()) :: K8s.Client.Provider.stream_response_t()
+  def stream(operation, wait_opts \\ [])
+
+  def stream(%Operation{conn: %Conn{} = conn} = operation, wait_opts),
+    do: Stream.run(conn, operation, wait_opts)
 
   @doc "alias of `K8s.Client.Runner.Stream.run/2`"
   defdelegate stream(conn, operation), to: Stream, as: :run
 
-  @spec stream(K8s.Conn.t(), K8s.Operation.t(), keyword) ::
-          {:error, K8s.Operation.Error.t()}
-          | {:ok,
-             ({:cont, any} | {:halt, any} | {:suspend, any}, any ->
-                :badarg | {:halted, any} | {:suspended, any, (any -> any)})}
   @doc "alias of `K8s.Client.Runner.Stream.run/3`"
   defdelegate stream(conn, operation, http_opts), to: Stream, as: :run
 

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -81,9 +81,17 @@ defmodule K8s.Client.Runner.Base do
   {:ok, result} = K8s.Client.Runner.Base.run(conn, operation)
   ```
   """
+  @spec run(Operation.t()) :: result_t
+  def run(%Operation{conn: %Conn{} = conn} = operation),
+    do: run(conn, operation, [])
+
   @spec run(Conn.t(), Operation.t()) :: result_t
   def run(%Conn{} = conn, %Operation{} = operation),
     do: run(conn, operation, [])
+
+  @spec run(Operation.t(), keyword()) :: result_t
+  def run(%Operation{conn: %Conn{} = conn} = operation, http_opts),
+    do: run(conn, operation, http_opts)
 
   @doc """
   Run a connect operation and pass `websocket_driver_opts` to `K8s.Client.WebSocketProvider`

--- a/lib/k8s/client/runner/stream.ex
+++ b/lib/k8s/client/runner/stream.ex
@@ -20,9 +20,15 @@ defmodule K8s.Client.Runner.Stream do
   @doc """
   Validates operation type before calling `stream/3`. Only supports verbs: `list_all_namespaces` and `list`.
   """
-  @spec run(Conn.t(), Operation.t(), keyword()) :: {:ok, Enumerable.t()} | {:error, Error.t()}
-  def run(conn, op, http_opts \\ [])
+  @spec run(Operation.t()) :: {:ok, Enumerable.t()} | {:error, Error.t()}
+  def run(%Operation{conn: %Conn{} = conn} = op), do: run(conn, op, [])
 
+  @spec run(Operation.t(), keyword()) :: {:ok, Enumerable.t()} | {:error, Error.t()}
+  def run(%Operation{conn: %Conn{} = conn} = op, http_opts), do: run(conn, op, http_opts)
+
+  def run(%Conn{} = conn, %Operation{} = op), do: run(conn, op, [])
+
+  @spec run(Conn.t(), Operation.t(), keyword()) :: {:ok, Enumerable.t()} | {:error, Error.t()}
   def run(%Conn{} = conn, %Operation{verb: verb} = op, http_opts)
       when verb in [:list, :list_all_namespaces] do
     op = name_as_field_selector(op)

--- a/lib/k8s/client/runner/wait.ex
+++ b/lib/k8s/client/runner/wait.ex
@@ -34,6 +34,10 @@ defmodule K8s.Client.Runner.Wait do
   resp = K8s.Client.Runner.Wait.run(conn, op, opts)
   ```
   """
+  @spec run(Operation.t(), keyword()) ::
+          {:ok, map()} | {:error, :timeout | Error.t()}
+  def run(%Operation{conn: %Conn{} = conn} = op, opts), do: run(conn, op, opts)
+
   @spec run(Conn.t(), Operation.t(), keyword()) ::
           {:ok, map()} | {:error, :timeout | Error.t()}
   def run(%Conn{} = conn, %Operation{method: :get} = op, opts) do

--- a/test/k8s/client/runner/base_test.exs
+++ b/test/k8s/client/runner/base_test.exs
@@ -146,8 +146,10 @@ defmodule K8s.Client.Runner.BaseTest do
 
   describe "run" do
     test "request with HTTP 2xx response", %{conn: conn} do
-      operation = Client.list("v1", "Namespace", [])
-      assert {:ok, _} = Base.run(conn, operation)
+      assert {:ok, _} =
+               Client.list("v1", "Namespace", [])
+               |> Client.put_conn(conn)
+               |> Client.run()
     end
 
     test "supports subresource operations with alternate `kind` HTTP bodies", %{conn: conn} do

--- a/test/k8s/client/runner/stream_integration_test.exs
+++ b/test/k8s/client/runner/stream_integration_test.exs
@@ -1,5 +1,4 @@
 defmodule K8s.Client.Runner.StreamIntegrationTest do
-  alias K8s.Client.Runner.Stream, as: MUT
   use ExUnit.Case, async: true
   import K8s.Test.IntegrationHelper
 
@@ -26,10 +25,11 @@ defmodule K8s.Client.Runner.StreamIntegrationTest do
     pod2 = pod("stream-nginx-#{test_id}-2", labels)
     {:ok, to_delete_2} = K8s.Client.run(conn, pod2)
 
-    selector = K8s.Selector.label(labels)
-    operation = K8s.Client.list("v1", "Pod", namespace: "default")
-    operation = K8s.Operation.put_selector(operation, selector)
-    assert {:ok, stream} = MUT.run(conn, operation)
+    assert {:ok, stream} =
+             K8s.Client.list("v1", "Pod", namespace: "default")
+             |> K8s.Operation.put_selector(K8s.Selector.label(labels))
+             |> K8s.Client.put_conn(conn)
+             |> K8s.Client.stream()
 
     resources =
       stream


### PR DESCRIPTION
The API until now (still supported):
```elixir
op = K8s.Client.get("v1", "pod", [name: "nginx", namespace: "default"])
K8s.Client.run(conn, op)
```

With this you can do:

```elixir
K8s.Client.get("v1", "pod", [name: "nginx", namespace: "default"])
|> K8s.Client.put_conn(conn)
|> K8s.Client.run()
```
 
---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [x] New unit tests were created
