### PR TITLE
add azure auth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+- Azure auth provider #225
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.0.1] - 2023-02-12

--- a/lib/k8s/client/mint_http_provider.ex
+++ b/lib/k8s/client/mint_http_provider.ex
@@ -194,7 +194,7 @@ defmodule K8s.Client.MintHTTPProvider do
   @spec get_content_type(keyword()) :: binary | nil
   defp get_content_type(headers) do
     case List.keyfind(headers, "content-type", 0) do
-      {_key, content_type} -> content_type
+      {_key, content_type} -> content_type |> String.split(";") |> List.first()
       _ -> nil
     end
   end

--- a/lib/k8s/conn/auth/azure.ex
+++ b/lib/k8s/conn/auth/azure.ex
@@ -1,0 +1,88 @@
+defmodule K8s.Conn.Auth.Azure do
+  @moduledoc """
+  `auth-provider` for azure
+  """
+  alias K8s.Conn.RequestOptions
+  @behaviour K8s.Conn.Auth
+
+  defstruct [:token]
+
+  @type t :: %__MODULE__{
+          token: String.t()
+        }
+
+  @impl true
+  @spec create(map, String.t()) :: {:ok, t} | :skip
+  def create(
+        %{
+          "auth-provider" => %{
+            "config" => %{
+              "access-token" => token,
+              "tenant-id" => tenant,
+              "expires-on" => expires_on,
+              "refresh-token" => refresh_token,
+              "client-id" => client_id,
+              "apiserver-id" => _apiserver_id
+            },
+            "name" => "azure"
+          }
+        },
+        _
+      ) do
+    if parse_expires(expires_on) <= DateTime.utc_now() do
+      # TODO current we don't have access to the credential file, so we wont be able to write the refresh token back into this, hence we will request a new token on every request when the original has expired
+      {:ok,
+       %__MODULE__{
+         token: refresh_token(tenant, refresh_token, client_id)
+       }}
+    else
+      {:ok,
+       %__MODULE__{
+         token: token
+       }}
+    end
+  end
+
+  def create(_, _), do: :skip
+
+  defp parse_expires(expires_on) do
+    case Integer.parse(expires_on) do
+      {expires_on, _} -> DateTime.from_unix!(expires_on)
+      :error -> DateTime.from_iso8601(expires_on)
+    end
+  end
+
+  defimpl RequestOptions, for: __MODULE__ do
+    @spec generate(K8s.Conn.Auth.Azure.t()) :: RequestOptions.generate_t()
+    def generate(%K8s.Conn.Auth.Azure{token: token}) do
+      {:ok,
+       %RequestOptions{
+         headers: [{:Authorization, "Bearer #{token}"}],
+         ssl_options: []
+       }}
+    end
+  end
+
+  defp refresh_token(
+         tenant,
+         refresh_token,
+         client_id
+       ) do
+    payload =
+      URI.encode_query(%{
+        "client_id" => client_id,
+        "grant_type" => "refresh_token",
+        "refresh_token" => refresh_token
+      })
+
+    HTTPoison.post!(
+      "https://login.microsoftonline.com/#{tenant}/oauth2/v2.0/token",
+      payload,
+      %{
+        "Content-Type" => "application/x-www-form-urlencoded"
+      }
+    ).body
+    |> Jason.decode!()
+    |> Map.get("access_token")
+  end
+end

--- a/lib/k8s/conn/auth/azure.ex
+++ b/lib/k8s/conn/auth/azure.ex
@@ -2,7 +2,6 @@ defmodule K8s.Conn.Auth.Azure do
   @moduledoc """
   `auth-provider` for azure
   """
-  alias K8s.Conn.Error
   alias K8s.Conn.RequestOptions
 
   require Logger
@@ -54,7 +53,7 @@ defmodule K8s.Conn.Auth.Azure do
   end
 
   @spec refresh_token(String.t(), String.t(), String.t(), String.t()) :: String.t()
-  defp refresh_token(tenant, refresh_token, client_id, _apiserver_id) do
+  def refresh_token(tenant, refresh_token, client_id, _apiserver_id) do
     payload =
       URI.encode_query(%{
         "client_id" => client_id,
@@ -67,13 +66,16 @@ defmodule K8s.Conn.Auth.Azure do
         :post,
         URI.new!("https://login.microsoftonline.com/#{tenant}/oauth2/v2.0/token"),
         payload,
-        %{
-          "Content-Type" => "application/x-www-form-urlencoded"
-        },
+        [
+          {
+            "Content-Type",
+            "application/x-www-form-urlencoded"
+          }
+        ],
         ssl: []
       )
 
-    res["access_token"]
+    Map.get(res, "access_token")
   end
 
   defimpl RequestOptions, for: __MODULE__ do

--- a/lib/k8s/conn/auth/azure.ex
+++ b/lib/k8s/conn/auth/azure.ex
@@ -30,7 +30,9 @@ defmodule K8s.Conn.Auth.Azure do
         _
       ) do
     if parse_expires(expires_on) <= DateTime.utc_now() do
-      # TODO current we don't have access to the credential file, so we wont be able to write the refresh token back into this, hence we will request a new token on every request when the original has expired
+      # TODO current we don't have access to the credential file,
+      # so we wont be able to write the refresh token back into this,
+      # hence we will request a new token on every request when the original has expired
       {:ok,
        %__MODULE__{
          token: refresh_token(tenant, refresh_token, client_id)
@@ -45,6 +47,7 @@ defmodule K8s.Conn.Auth.Azure do
 
   def create(_, _), do: :skip
 
+  @spec parse_expires(String.t()) :: DateTime.t()
   defp parse_expires(expires_on) do
     case Integer.parse(expires_on) do
       {expires_on, _} -> DateTime.from_unix!(expires_on)
@@ -63,6 +66,7 @@ defmodule K8s.Conn.Auth.Azure do
     end
   end
 
+  @spec refresh_token(String.t(), String.t(), String.t()) :: String.t()
   defp refresh_token(
          tenant,
          refresh_token,

--- a/test/k8s/conn/auth/azure_test.exs
+++ b/test/k8s/conn/auth/azure_test.exs
@@ -28,30 +28,6 @@ defmodule K8s.Conn.Auth.AzureTest do
                 token: "xxx"
               }} = Azure.create(auth, nil)
     end
-
-    @tag :skip
-    test "fails when token is expired" do
-      expired_unix_ts = DateTime.utc_now() |> DateTime.add(-10, :minute) |> DateTime.to_unix()
-
-      auth = %{
-        "auth-provider" => %{
-          "config" => %{
-            "access-token" => "xxx",
-            "apiserver-id" => "service_id",
-            "client-id" => "client_id",
-            "expires-on" => "#{expired_unix_ts}",
-            "refresh-token" => "yyy",
-            "tenant-id" => "tenant"
-          },
-          "name" => "azure"
-        }
-      }
-
-      assert {:error,
-              %K8s.Conn.Error{
-                message: "Azure token expired please refresh manually"
-              }} = Azure.create(auth, nil)
-    end
   end
 
   test "creates http request signing options" do

--- a/test/k8s/conn/auth/azure_test.exs
+++ b/test/k8s/conn/auth/azure_test.exs
@@ -1,0 +1,67 @@
+defmodule K8s.Conn.Auth.AzureTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias K8s.Conn
+  alias K8s.Conn.Auth.Azure
+
+  describe "create/2" do
+    test "creates a Azure struct from  data" do
+      non_expired_unix_ts = DateTime.utc_now() |> DateTime.add(10, :minute) |> DateTime.to_unix()
+
+      auth = %{
+        "auth-provider" => %{
+          "config" => %{
+            "access-token" => "xxx",
+            "apiserver-id" => "service_id",
+            "client-id" => "client_id",
+            "expires-on" => "#{non_expired_unix_ts}",
+            "refresh-token" => "yyy",
+            "tenant-id" => "tenant"
+          },
+          "name" => "azure"
+        }
+      }
+
+      assert {:ok,
+              %Azure{
+                token: "xxx"
+              }} = Azure.create(auth, nil)
+    end
+
+    test "fails when token is expired" do
+      expired_unix_ts = DateTime.utc_now() |> DateTime.add(-10, :minute) |> DateTime.to_unix()
+
+      auth = %{
+        "auth-provider" => %{
+          "config" => %{
+            "access-token" => "xxx",
+            "apiserver-id" => "service_id",
+            "client-id" => "client_id",
+            "expires-on" => "#{expired_unix_ts}",
+            "refresh-token" => "yyy",
+            "tenant-id" => "tenant"
+          },
+          "name" => "azure"
+        }
+      }
+
+      assert {:error,
+              %K8s.Conn.Error{
+                message: "Azure token expired please refresh manually"
+              }} = Azure.create(auth, nil)
+    end
+  end
+
+  test "creates http request signing options" do
+    provider = %Azure{
+      token: "xxx"
+    }
+
+    {:ok, %Conn.RequestOptions{headers: headers, ssl_options: ssl_options}} =
+      Conn.RequestOptions.generate(provider)
+
+    assert headers == [{:Authorization, "Bearer xxx"}]
+    assert ssl_options == []
+  end
+end

--- a/test/k8s/conn/auth/azure_test.exs
+++ b/test/k8s/conn/auth/azure_test.exs
@@ -29,6 +29,7 @@ defmodule K8s.Conn.Auth.AzureTest do
               }} = Azure.create(auth, nil)
     end
 
+    @tag :skip
     test "fails when token is expired" do
       expired_unix_ts = DateTime.utc_now() |> DateTime.add(-10, :minute) |> DateTime.to_unix()
 


### PR DESCRIPTION
<!-- Describe your pull request here. !-->
Added barebone azure auth provider.
Currently, it is missing one functionality which is tagged in the code as a TODO, this is writing back the refreshed token when a new one is generated with a refresh token. I am not sure this is possible with the current setup?

My previous implementation used httppoison to make the refresh token request, what is your opinion on this, should we use mint or depend on one more library? If we use mint I might need a little help getting it to work.

Based on https://github.com/kubernetes-client/python/blob/055fa706b8677207091251998dca80cab5d5afb0/kubernetes/base/config/kube_config.py#L317
closes: #162 

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->



#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [x] New unit tests were created
- [ ] New integration tests were created
- [ ] PR description contains a link to the according kubernetes documentation
