### PR TITLE
configurable http headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- `K8s.Client.Runner.Base.run/3` and `K8s.Client.run/3` - Support for custom http headers via http_opts - [#228](https://github.com/coryodaniel/k8s/pull/228)
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.0.3] - 2023-02-17

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -80,6 +80,15 @@ defmodule K8s.Client.Runner.Base do
   {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml")
   {:ok, result} = K8s.Client.Runner.Base.run(conn, operation)
   ```
+
+  Setting custom http headers.  Existing headers will be overridden
+
+  ```elixir
+  {:ok, conn} = K8s.Conn.from_file("test/support/kube-config.yaml")
+  operation = K8s.Client.list("v1", "Pod", namespace: :all)
+  http_opts = [headers: ["Foo": "Bar"]]
+  {:ok, %{"items" => pods}} = K8s.Client.run(conn, operation, http_opts)
+  ```
   """
   @spec run(Operation.t()) :: result_t
   def run(%Operation{conn: %Conn{} = conn} = operation),
@@ -205,6 +214,7 @@ defmodule K8s.Client.Runner.Base do
         :apply -> ["Content-Type": "application/apply-patch+yaml"]
         _ -> ["Content-Type": "application/json"]
       end
+      |> Keyword.merge(Keyword.get(http_opts, :headers, []))
 
     operation_query_params = build_query_params(operation)
     http_opts_params = Keyword.get(http_opts, :params, [])


### PR DESCRIPTION
Allows for custom http headers via `http_opts` (`:headers`) in `K8s.Client.Runner.Base.run/3` and `K8s.Client.run/3`

Resolves #227 