### PR TITLE
Add further patch mechanisms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added operation header_params - [#229](https://github.com/coryodaniel/k8s/pull/229)
+- Added further PATCH mechanisms - [#229](https://github.com/coryodaniel/k8s/pull/229)
 
 <!--------------------- Don't add new entries after this line --------------------->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- Added operation header_params - [#229](https://github.com/coryodaniel/k8s/pull/229)
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.0.3] - 2023-02-17

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -86,19 +86,20 @@ defmodule K8s.Client do
       ...> K8s.Client.apply(deployment, field_manager: "my-operator", force: true)
       %K8s.Operation{
         method: :patch,
-        verb: :apply,
+        verb: :patch,
         api_version: "apps/v1",
         name: "Deployment",
         path_params: [namespace: "test", name: "nginx"],
         data: K8s.Resource.from_file!("test/support/manifests/nginx-deployment.yaml"),
-        query_params: [fieldManager: "my-operator", force: true]
+        query_params: [fieldManager: "my-operator", force: true],
+        header_params: ["Content-Type": "application/apply-patch+yaml"],
       }
   """
   @spec apply(map(), keyword()) :: Operation.t()
   def apply(resource, mgmt_params \\ []) do
     field_manager = Keyword.get(mgmt_params, :field_manager, @mgmt_param_defaults[:field_manager])
     force = Keyword.get(mgmt_params, :force, @mgmt_param_defaults[:force])
-    Operation.build(:apply, resource, field_manager: field_manager, force: force, patch_type: :apply)
+    Operation.build(:patch, resource, field_manager: field_manager, force: force, patch_type: :apply)
   end
 
   @doc """
@@ -111,12 +112,13 @@ defmodule K8s.Client do
       ...> K8s.Client.apply("v1", "pods/status", [namespace: "default", name: "nginx"], pod_with_status_subresource, field_manager: "my-operator", force: true)
       %K8s.Operation{
         method: :patch,
-        verb: :apply,
+        verb: :patch,
         api_version: "v1",
         name: "pods/status",
         path_params: [namespace: "default", name: "nginx"],
         data: K8s.Resource.from_file!("test/support/manifests/nginx-pod.yaml") |> Map.put("status", %{"message" => "some message"}),
-        query_params: [fieldManager: "my-operator", force: true]
+        query_params: [fieldManager: "my-operator", force: true],
+        header_params: ["Content-Type": "application/apply-patch+yaml"]
       }
   """
   @spec apply(binary, Operation.name_t(), Keyword.t(), map(), keyword()) :: Operation.t()
@@ -130,7 +132,7 @@ defmodule K8s.Client do
     field_manager = Keyword.get(mgmt_params, :field_manager, @mgmt_param_defaults[:field_manager])
     force = Keyword.get(mgmt_params, :force, @mgmt_param_defaults[:force])
 
-    Operation.build(:apply, api_version, kind, path_params, subresource,
+    Operation.build(:patch, api_version, kind, path_params, subresource,
       field_manager: field_manager,
       force: force,
       patch_type: :apply
@@ -437,7 +439,8 @@ defmodule K8s.Client do
         api_version: "apps/v1",
         name: "Deployment",
         path_params: [namespace: "test", name: "nginx"],
-        data: K8s.Resource.from_file!("test/support/manifests/nginx-deployment.yaml")
+        data: K8s.Resource.from_file!("test/support/manifests/nginx-deployment.yaml"),
+        header_params: ["Content-Type": "application/merge-patch+json"]
       }
   """
   @spec patch(map()) :: Operation.t()

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -98,7 +98,7 @@ defmodule K8s.Client do
   def apply(resource, mgmt_params \\ []) do
     field_manager = Keyword.get(mgmt_params, :field_manager, @mgmt_param_defaults[:field_manager])
     force = Keyword.get(mgmt_params, :force, @mgmt_param_defaults[:force])
-    Operation.build(:apply, resource, field_manager: field_manager, force: force)
+    Operation.build(:apply, resource, field_manager: field_manager, force: force, patch_type: :apply)
   end
 
   @doc """
@@ -132,7 +132,8 @@ defmodule K8s.Client do
 
     Operation.build(:apply, api_version, kind, path_params, subresource,
       field_manager: field_manager,
-      force: force
+      force: force,
+      patch_type: :apply
     )
   end
 
@@ -440,33 +441,35 @@ defmodule K8s.Client do
       }
   """
   @spec patch(map()) :: Operation.t()
-  def patch(%{} = resource), do: Operation.build(:patch, resource)
+  def patch(%{} = resource), do: Operation.build(:patch, resource, patch_type: :merge)
 
   @doc """
   Returns a `PATCH` operation to patch the given subresource given a resource's details and a subresource map.
   """
-  @spec patch(binary, Operation.name_t(), Keyword.t(), map()) :: Operation.t()
-  def patch(api_version, kind, path_params, subresource),
-    do: Operation.build(:patch, api_version, kind, path_params, subresource)
+  @spec patch(binary, Operation.name_t(), Keyword.t(), map(), patch_type :: Operation.patch_type()) :: Operation.t()
+  def patch(api_version, kind, path_params, subresource, patch_type \\ :merge),
+    do: Operation.build(:patch, api_version, kind, path_params, subresource, patch_type: patch_type)
 
   @doc """
   Returns a `PATCH` operation to patch the given subresource given a resource map and a subresource map.
   """
-  @spec patch(map(), map()) :: Operation.t()
+  @spec patch(map(), map(), patch_type :: Operation.patch_type()) :: Operation.t()
   def patch(
         %{
           "apiVersion" => api_version,
           "kind" => kind,
           "metadata" => %{"namespace" => ns, "name" => name}
         },
-        %{"kind" => subkind} = subresource
+        %{"kind" => subkind} = subresource,
+        patch_type \\ :merge
       ) do
     Operation.build(
       :patch,
       api_version,
       {kind, subkind},
       [namespace: ns, name: name],
-      subresource
+      subresource,
+      patch_type: patch_type
     )
   end
 

--- a/lib/k8s/client.ex
+++ b/lib/k8s/client.ex
@@ -99,7 +99,12 @@ defmodule K8s.Client do
   def apply(resource, mgmt_params \\ []) do
     field_manager = Keyword.get(mgmt_params, :field_manager, @mgmt_param_defaults[:field_manager])
     force = Keyword.get(mgmt_params, :force, @mgmt_param_defaults[:force])
-    Operation.build(:patch, resource, field_manager: field_manager, force: force, patch_type: :apply)
+
+    Operation.build(:patch, resource,
+      field_manager: field_manager,
+      force: force,
+      patch_type: :apply
+    )
   end
 
   @doc """
@@ -449,9 +454,16 @@ defmodule K8s.Client do
   @doc """
   Returns a `PATCH` operation to patch the given subresource given a resource's details and a subresource map.
   """
-  @spec patch(binary, Operation.name_t(), Keyword.t(), map(), patch_type :: Operation.patch_type()) :: Operation.t()
+  @spec patch(
+          binary,
+          Operation.name_t(),
+          Keyword.t(),
+          map(),
+          patch_type :: Operation.patch_type()
+        ) :: Operation.t()
   def patch(api_version, kind, path_params, subresource, patch_type \\ :merge),
-    do: Operation.build(:patch, api_version, kind, path_params, subresource, patch_type: patch_type)
+    do:
+      Operation.build(:patch, api_version, kind, path_params, subresource, patch_type: patch_type)
 
   @doc """
   Returns a `PATCH` operation to patch the given subresource given a resource map and a subresource map.

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -200,6 +200,9 @@ defmodule K8s.Client.Runner.Base do
     req = %Request{conn: conn, method: operation.method, body: body}
 
     headers =
+      # This functionality is duplicated in Operation.build/6, however, we are leaving it in
+      # to prevent a breaking change in the case an operation was being created without using
+      # Operation.build/6
       case operation.verb do
         :patch -> ["Content-Type": "application/merge-patch+json"]
         :apply -> ["Content-Type": "application/apply-patch+yaml"]

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -199,17 +199,7 @@ defmodule K8s.Client.Runner.Base do
   defp new_request(%Conn{} = conn, url, %Operation{} = operation, body, http_opts) do
     req = %Request{conn: conn, method: operation.method, body: body}
 
-    headers =
-      # This functionality is duplicated in Operation.build/6, however, we are leaving it in
-      # to prevent a breaking change in the case an operation was being created without using
-      # Operation.build/6
-      case operation.verb do
-        :patch -> ["Content-Type": "application/merge-patch+json"]
-        :apply -> ["Content-Type": "application/apply-patch+yaml"]
-        _ -> ["Content-Type": "application/json"]
-      end
-      |> Keyword.merge(operation.header_params)
-
+    headers = operation.header_params
     operation_query_params = build_query_params(operation)
     http_opts_params = Keyword.get(http_opts, :params, [])
     merged_params = Keyword.merge(operation_query_params, http_opts_params)

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -205,6 +205,7 @@ defmodule K8s.Client.Runner.Base do
         :apply -> ["Content-Type": "application/apply-patch+yaml"]
         _ -> ["Content-Type": "application/json"]
       end
+      |> Keyword.merge(operation.header_params)
 
     operation_query_params = build_query_params(operation)
     http_opts_params = Keyword.get(http_opts, :params, [])

--- a/lib/k8s/operation.ex
+++ b/lib/k8s/operation.ex
@@ -210,15 +210,21 @@ defmodule K8s.Operation do
       case {verb, patch_type} do
         {:patch, merge_patch_types} when merge_patch_types in [:merge, :not_set] ->
           @patch_type_header_map[:merge]
+
         {:patch, :strategic_merge} ->
           @patch_type_header_map[:strategic_merge]
+
         {:patch, :json_merge} ->
           @patch_type_header_map[:json_merge]
+
         {:patch, :apply} ->
           @patch_type_header_map[:apply]
+
         {:apply, apply_patch_types} when apply_patch_types in [:apply, :not_set] ->
           @patch_type_header_map[:apply]
-        _ -> ["Content-Type": "application/json"]
+
+        _ ->
+          ["Content-Type": "application/json"]
       end
       |> Keyword.merge(Keyword.get(opts, :header_params, []))
 


### PR DESCRIPTION
Adds Operation.header_params which are used with K8s.Client.patch and K8s.Client.apply, allowing for alternate patch types.

Resolves #227 