### PR TITLE
Avoid Passing `nil` in Exec Call

### DIFF
--- a/lib/k8s/conn/auth/exec.ex
+++ b/lib/k8s/conn/auth/exec.ex
@@ -86,7 +86,9 @@ defmodule K8s.Conn.Auth.Exec do
   @spec generate_token(t) ::
           {:ok, binary} | {:error, Jason.DecodeError.t() | Error.t()}
   def generate_token(config) do
-    with {cmd_response, 0} <- System.cmd(config.command, config.args, env: config.env),
+
+    with args <- config.args || [],
+         {cmd_response, 0} <- System.cmd(config.command, args, env: config.env),
          {:ok, data} <- Jason.decode(cmd_response),
          {:ok, token} when not is_nil(token) <- parse_cmd_response(data) do
       {:ok, token}


### PR DESCRIPTION
Currently, if you're using GKE and an updated Kube cluster with the `gke-auth-plugin` (https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke), it'll write a config file that looks like 

```
users: 
- name: <CLUSTER>
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      command: /Users/peixian/miniconda3/envs/gcloud/share/google-cloud-sdk-390.0.0-0/bin/gke-gcloud-auth-plugin
      installHint: Install gke-gcloud-auth-plugin for use with kubectl by following
        https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
      provideClusterInfo: true
```

This doesn't set an `args`, which causes a nil error when checking `config.args`. This PR just adds a null default for cases like this.

#### Requirements for all pull requests

- [ ] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [ ] New unit tests were created
- [ ] New integration tests were created
- [ ] PR description contains a link to the according kubernetes documentation
