### PR TITLE
shutdown genserver without raising exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Fixed
+
+- `K8s.Client.Mint.HTTPAdapter` - Don't raise exception when terminating an adapter. - [#268](https://github.com/coryodaniel/k8s/issues/268), [#269](https://github.com/coryodaniel/k8s/pull/269)
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.4.0] - 2023-07-07

--- a/lib/k8s/client/mint/http_adapter.ex
+++ b/lib/k8s/client/mint/http_adapter.ex
@@ -239,7 +239,7 @@ defmodule K8s.Client.Mint.HTTPAdapter do
         &Request.recv(&1, from)
       )
 
-    {:noreply, state}
+    shutdown_if_closed(state)
   end
 
   @impl true
@@ -265,9 +265,7 @@ defmodule K8s.Client.Mint.HTTPAdapter do
       {:error, conn, %Mint.TransportError{reason: :closed}, []} ->
         Logger.debug("The connection was closed.", library: :k8s)
 
-        # We could terminate the process here. But there might still be chunks
-        # in the buffer, so we let the healthcheck take care of that.
-        {:noreply, struct!(state, conn: conn)}
+        shutdown_if_closed(struct!(state, conn: conn))
 
       {:error, conn, error} ->
         Logger.warning(
@@ -332,11 +330,8 @@ defmodule K8s.Client.Mint.HTTPAdapter do
   # it's not open, and all buffers are emptied, this process is considered
   # garbage and is stopped.
   def handle_info(:healthcheck, state) do
-    any_non_empty_buffers? =
-      Enum.any?(state.requests, fn {_, request} -> request.buffer != [] end)
-
-    if Mint.HTTP.open?(state.conn) or any_non_empty_buffers? do
-      Process.send_after(self(), :healthcheck, @healthcheck_freq * 1_000)
+    if Mint.HTTP.open?(state.conn) or any_non_empty_buffers?(state) do
+      Process.send_after(self(), :healthcheck, @healthcheck_freq * 1000)
       {:noreply, state}
     else
       Logger.warning(
@@ -454,5 +449,24 @@ defmodule K8s.Client.Mint.HTTPAdapter do
       end)
 
     {:noreply, state}
+  end
+
+  @spec shutdown_if_closed(t()) :: {:noreply, t()} | {:stop, {:shutdown, :closed}, t()}
+  defp shutdown_if_closed(state) do
+    if Mint.HTTP.open?(state.conn) or any_non_empty_buffers?(state) do
+      {:noreply, state}
+    else
+      Logger.warning(
+        log_prefix("Connection closed for reading and writing - stopping this process."),
+        library: :k8s
+      )
+
+      {:stop, {:shutdown, :closed}, state}
+    end
+  end
+
+  @spec any_non_empty_buffers?(t()) :: boolean()
+  defp any_non_empty_buffers?(state) do
+    Enum.any?(state.requests, fn {_, request} -> request.buffer != [] end)
   end
 end

--- a/lib/k8s/client/mint/http_adapter.ex
+++ b/lib/k8s/client/mint/http_adapter.ex
@@ -344,7 +344,7 @@ defmodule K8s.Client.Mint.HTTPAdapter do
         library: :k8s
       )
 
-      {:stop, :closed, state}
+      {:stop, {:shutdown, :closed}, state}
     end
   end
 


### PR DESCRIPTION
When an adapter needs to be terminated, we should pass a reason that doesn't treat the termination like a crash of the process and therefore doesn't raise an exception.

refs #268 

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created
