### PR TITLE
chore(K8s.Client.Runner.Stream.Watch): fix type

### DIFF
--- a/lib/k8s/client/runner/stream/watch.ex
+++ b/lib/k8s/client/runner/stream/watch.ex
@@ -102,7 +102,7 @@ defmodule K8s.Client.Runner.Stream.Watch do
 
   defp reduce(:done, state) do
     Logger.debug(
-      log_prefix("Watcher termineated the request. Starting a new watch request."),
+      log_prefix("Watcher terminated the request. Starting a new watch request."),
       library: :k8s
     )
 


### PR DESCRIPTION

Fixes spelling of `terminated`

#### Requirements for all pull requests

- [ ] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [ ] New unit tests were created
- [ ] New integration tests were created
- [ ] PR description contains a link to the according kubernetes documentation
