### PR TITLE
fix: only stop genserver if connection is closed for reading, too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Fixed
+
+- `K8s.Client.Mint.HTTPAdapter` - Only stop the process if the connection is closed for reading (and writing). - [#280](https://github.com/coryodaniel/k8s/issues/280), [#285](https://github.com/coryodaniel/k8s/pull/285)
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.4.1] - 2023-08-15

--- a/lib/k8s/client/mint/http_adapter.ex
+++ b/lib/k8s/client/mint/http_adapter.ex
@@ -330,7 +330,7 @@ defmodule K8s.Client.Mint.HTTPAdapter do
   # it's not open, and all buffers are emptied, this process is considered
   # garbage and is stopped.
   def handle_info(:healthcheck, state) do
-    if Mint.HTTP.open?(state.conn) or any_non_empty_buffers?(state) do
+    if Mint.HTTP.open?(state.conn, :read) or any_non_empty_buffers?(state) do
       Process.send_after(self(), :healthcheck, @healthcheck_freq * 1000)
       {:noreply, state}
     else
@@ -453,7 +453,7 @@ defmodule K8s.Client.Mint.HTTPAdapter do
 
   @spec shutdown_if_closed(t()) :: {:noreply, t()} | {:stop, {:shutdown, :closed}, t()}
   defp shutdown_if_closed(state) do
-    if Mint.HTTP.open?(state.conn) or any_non_empty_buffers?(state) do
+    if Mint.HTTP.open?(state.conn, :read) or any_non_empty_buffers?(state) do
       {:noreply, state}
     else
       Logger.warning(


### PR DESCRIPTION
We only want to stop the process if the HTTP connection is closed for both reading AND writing. Apparently, if it is NOT open or reading AND writing it might still be open just for reading. Hence we need to check passing `:read` as `type` to `Mint.open?/2`.

closes #280

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created

