### PR TITLE
remove docs and examples including insecure_skip_tls_verify

### DIFF
--- a/.github/workflows/elixir_matrix.yaml
+++ b/.github/workflows/elixir_matrix.yaml
@@ -14,10 +14,12 @@ jobs:
       matrix:
         # See https://hexdocs.pm/elixir/1.13/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
         otp: ["23.x", "24.x", "25.x", "26.x"]
-        elixir: ["1.14.x", "1.15.x"]
+        elixir: ["1.14.x", "1.15.x", "1.16.x"]
         exclude:
           # OTP 23
           - elixir: "1.15.x"
+            otp: "23.x"
+          - elixir: "1.16.x"
             otp: "23.x"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--------------------- Don't add new entries after this line --------------------->
 
+### Fixed
+
+- With the upgrade to `mint` 1.6.0, there's no need for setting
+  `insecure_skip_tls_verify: true` anymore in most cases.
+  (https://github.com/elixir-mint/mint/pull/418). Documentation and examples
+  were adapted.
+
 ## [2.6.0] - 2024-04-02
 
 ### Added

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -19,7 +19,7 @@ The options passed as second argument are the same as for `K8s.Conn.from_file/2`
 To pass the env variable explicitely and specify options:
 
 ```elixir
-{:ok, conn} = K8s.Conn.from_env("K8S_CONFIG_FILE", insecure_skip_tls_verify: true)
+{:ok, conn} = K8s.Conn.from_env("K8S_CONFIG_FILE")
 ```
 
 **Using `K8s.Conn.from_file/2`:**

--- a/guides/migrations.md
+++ b/guides/migrations.md
@@ -106,20 +106,6 @@ receive do
 end
 ```
 
-
-### Local Clusters and TLS Hostname Verification
-
-Local clusters are usually accessed via IP address so the hostname provided by
-the TLS certificate can't match the actual hostname (IP address). While somehow
-HTTPoison was OK with this, Mint declines the HTTPS connection. In order to make
-this work, you have to disable TLS peer verification. See also issue
-[#203](https://github.com/coryodaniel/k8s/issues/203)
-
-```elixir
-{:ok, conn} = K8s.Conn.from_file(...)
-conn = struct!(conn, insecure_skip_tls_verify: true)
-```
-
 ### HTTPoison was removed
 
 Wherever you match against `HTTPoison.*`, you're gonna have to change your code.

--- a/lib/k8s/conn.ex
+++ b/lib/k8s/conn.ex
@@ -102,14 +102,11 @@ defmodule K8s.Conn do
   {:ok, conn} = K8s.Conn.from_file("~/.kube/config")
   ```
 
-  Pass the context and allow insecure TLS verification :
+  Pass the context:
 
   ```
   {:ok, conn} =
-    K8s.Conn.from_file("~/.kube/config",
-      context: "my-kind-cluster",
-      insecure_skip_tls_verify: true
-    )
+    K8s.Conn.from_file("~/.kube/config", context: "my-kind-cluster")
   ```
 
   ### Options
@@ -178,26 +175,7 @@ defmodule K8s.Conn do
 
   ```
   {:ok, conn} =
-    K8s.Conn.from_service_account("/path/to/token",
-      insecure_skip_tls_verify: true
-    )
-  ```
-
-  Allow insecure TLS verification:
-
-  ```
-  {:ok, conn} =
-    K8s.Conn.from_service_account(
-      insecure_skip_tls_verify: true
-    )
-  ```
-
-  ```
-  {:ok, conn} =
-    K8s.Conn.from_service_account(
-      "/path/to/token",
-      insecure_skip_tls_verify: true
-    )
+    K8s.Conn.from_service_account("/path/to/token")
   ```
   """
   @spec from_service_account(service_account_path :: String.t(), opts :: Keyword.t()) ::

--- a/test/support/integration_helper.ex
+++ b/test/support/integration_helper.ex
@@ -5,7 +5,6 @@ defmodule K8s.Test.IntegrationHelper do
   def conn do
     {:ok, conn} =
       K8s.Conn.from_env(
-        insecure_skip_tls_verify: true,
         discovery_driver: K8s.Discovery.Driver.HTTP,
         discovery_opts: [],
         http_provider: K8s.Client.MintHTTPProvider


### PR DESCRIPTION
Mint 1.6.0 was just released, including this PR: https://github.com/elixir-mint/mint/pull/418. Now we can finally safely omit `insecure_skip_tls_verify: :true` when creating connections.

---

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created
