### PR TITLE
Update asdf elixir version for gradual typing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Setup elixir
         uses: erlef/setup-beam@v1
+        id: beam
         with:
           version-file: .tool-versions
           version-type: strict
@@ -51,8 +52,6 @@ jobs:
         id: plt-cache
         with:
           key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
-          restore-keys: |
             ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
           path: |
             priv/plts

--- a/.github/workflows/elixir_matrix.yaml
+++ b/.github/workflows/elixir_matrix.yaml
@@ -13,14 +13,24 @@ jobs:
       fail-fast: false
       matrix:
         # See https://hexdocs.pm/elixir/1.13/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
-        otp: ["23.x", "24.x", "25.x", "26.x"]
-        elixir: ["1.14.x", "1.15.x", "1.16.x"]
+        otp: ["23.x", "26.x", "27.x"]
+        elixir: ["1.14.x", "1.17.x", "1.18.x"]
         exclude:
           # OTP 23
           - elixir: "1.15.x"
             otp: "23.x"
-          - elixir: "1.16.x"
+          - elixir: "1.17.x"
             otp: "23.x"
+          - elixir: "1.18.x"
+            otp: "23.x"
+          # OTP 26 
+          # - Users on recent elixir likely updated OTP versions
+          - elixir: "1.18.x"
+            otp: "26.x"
+          # OTP 27 - Elixir 1.14.x is not compatible with OTP 27
+          - elixir: "1.14.x"
+            otp: "27.x"
+          
 
     steps:
       - uses: actions/checkout@v4.1.7

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-erlang 26.0.2
-elixir 1.15.2
+erlang 27.1.2
+elixir 1.18.1-otp-27
 k3d 5.4.6
-kind 0.19.0
+kind 0.25.0

--- a/lib/k8s/client/runner/stream/list_request.ex
+++ b/lib/k8s/client/runner/stream/list_request.ex
@@ -40,9 +40,6 @@ defmodule K8s.Client.Runner.Stream.ListRequest do
          {:ok, items} <- Map.fetch(response, "items") do
       {items, struct!(state, continue: cont)}
     else
-      :halt ->
-        {:halt, nil}
-
       :error ->
         {:halt, nil}
 


### PR DESCRIPTION
chore: update asdf elixir/otp versions

Summary:
- The latest elixir has nice gradual typing. This PR updates to the
  latest version to bring that in.
- Bump OTP as well

Test Plan:
- make integration.kind
- mix compile --force --warnings-as-errors
