### PR TITLE
fix: allow http body types in the Base runner return

### DIFF
--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -3,6 +3,9 @@ defmodule K8s.Client.Runner.Base do
   Base HTTP processor for `K8s.Client`.
   """
 
+  @typedoc "Acceptable HTTP body types"
+  @type body_t :: list(map()) | map() | binary() | nil
+
   @type error_t ::
           {:error, K8s.Middleware.Error.t()}
           | {:error, K8s.Operation.Error.t()}
@@ -10,10 +13,7 @@ defmodule K8s.Client.Runner.Base do
           | {:error, K8s.Discovery.Error.t()}
           | {:error, atom()}
           | {:error, binary()}
-  @type result_t :: {:ok, map() | reference()} | error_t
-
-  @typedoc "Acceptable HTTP body types"
-  @type body_t :: list(map()) | map() | binary() | nil
+  @type result_t :: {:ok, map() | reference() | body_t} | error_t
 
   alias K8s.Conn
   alias K8s.Middleware.Request


### PR DESCRIPTION
Summary:

Add existing `body_t` to `return_t` for Client.Runner.Base. This allows the base runner to return binary data. This happens when asking for a subresource.


Fixes: coryodaniel/k8s#352

