### PR TITLE
Support nanocpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- Add support for nanocpu (`n`) units in `K8s.Resource.Utilization.cpu`.  [Issue #373](https://github.com/coryodaniel/k8s/issues/373)
+
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.7.0] - 2025-01-09

--- a/lib/k8s/resource/utilization.ex
+++ b/lib/k8s/resource/utilization.ex
@@ -57,6 +57,7 @@ defmodule K8s.Resource.Utilization do
 
     case maybe_millicpu do
       "m" -> value / 1000
+      "n" -> value / 1_000_000_000
       _ -> value
     end
   end

--- a/test/k8s/resource/utilization_test.exs
+++ b/test/k8s/resource/utilization_test.exs
@@ -1,0 +1,42 @@
+defmodule K8s.Resource.UtilizationTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  doctest K8s.Resource.Utilization
+
+  alias K8s.Resource.Utilization, as: U
+
+  describe "cpu/1" do
+    test "parses whole values" do
+      assert U.cpu("3") == 3
+    end
+
+    test "parses millicpu values" do
+      assert U.cpu("500m") == 0.5
+    end
+
+    test "parses nanocpu values" do
+      assert U.cpu("900000n") == 0.0009
+    end
+
+    test "parses decimal values" do
+      assert U.cpu("1.5") == 1.5
+    end
+
+    test "handles nil input" do
+      assert U.cpu(nil) == 0
+    end
+
+    test "handles negative values" do
+      assert U.cpu("-500m") == -0.5
+    end
+
+    test "handles positive prefixed values" do
+      assert U.cpu("+500m") == 0.5
+    end
+
+    test "handles invalid input gracefully" do
+      assert_raise MatchError, fn -> U.cpu("no match of right hand side value: :error") end
+    end
+  end
+end


### PR DESCRIPTION

Adds support for the `n` (nanocpu/nanocore) unit, if found.  Typically from the Metrics endpoint.
https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#cpu-units
The `n` unit is not mentioned, but is used by the Metrics endpoint.

---

#### Requirements for all pull requests

- [X] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [X] New unit tests were created
- [ ] New integration tests were created
- [X] PR description contains a link to the according kubernetes documentation
