### PR TITLE
Fix compiler warnings for elixir 1.19+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-<!-- Add your changelog entry to the relevant subsection -->
+### Fixed
 
-<!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
-
+- Fix compiler warnings on Elixir 1.19+ (struct type annotations, unused `require Logger`).
 <!--------------------- Don't add new entries after this line --------------------->
 
 ## [2.8.0] - 2025-10-11

--- a/lib/k8s/client/runner/base.ex
+++ b/lib/k8s/client/runner/base.ex
@@ -19,8 +19,6 @@ defmodule K8s.Client.Runner.Base do
   alias K8s.Middleware.Request
   alias K8s.Operation
 
-  require Logger
-
   @doc """
   Runs a `K8s.Operation`.
 

--- a/lib/k8s/conn/auth/service_account_worker.ex
+++ b/lib/k8s/conn/auth/service_account_worker.ex
@@ -62,7 +62,7 @@ defmodule K8s.Conn.Auth.ServiceAccountWorker do
   @impl true
   def init(args) do
     # Parse the args
-    starting_state = struct!(State, args)
+    %State{} = starting_state = struct!(State, args)
 
     # Start a refresh timer for just about now.
     {:ok,
@@ -152,7 +152,7 @@ defmodule K8s.Conn.Auth.ServiceAccountWorker do
   end
 
   @spec reset_timer(State.t()) :: State.t()
-  defp reset_timer(state) do
+  defp reset_timer(%State{} = state) do
     if state.timer != nil do
       Process.cancel_timer(state.timer)
     end


### PR DESCRIPTION
<!-- Describe your pull request here. !-->

While using the library on elixir 1.19+ there were compiler warnings emitted on every compile. The warnings were related to type violation on struct update syntax. I have added pattern match before performing updates as recommended by the compiler alongside the emitted warnings.

<!-- In order for this pull request to be merged it has to fulfill the following requirements: -->

#### Requirements for all pull requests

- [x] Entry in CHANGELOG.md was created

#### Additional requirements for new features

- [ ] New unit tests were created
- [ ] New integration tests were created
- [ ] PR description contains a link to the according kubernetes documentation
